### PR TITLE
Synchronize recent patches from upstream firecracker/micro-http 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,16 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "epoll"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990bcfe26bea89669ede68c3f970f61d02568dbc8660317c98d805ea4e710685"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,5 +16,16 @@ checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 name = "micro_http"
 version = "0.2.0"
 dependencies = [
- "epoll",
+ "libc",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
+dependencies = [
+ "bitflags",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-epoll = ">=4.0.1"
+libc = ">=0.2.39"
+vmm-sys-util = ">=0.6.1"

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.5, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.8, "exclude_path": "", "crate_features": ""}

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -179,15 +179,6 @@ impl Headers {
         self.expect
     }
 
-    #[cfg(test)]
-    pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
-        Self {
-            content_length,
-            expect,
-            chunked,
-        }
-    }
-
     /// Parses a byte slice into a Headers structure for a HTTP request.
     ///
     /// The byte slice is expected to have the following format: </br>
@@ -298,6 +289,16 @@ impl MediaType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    impl Headers {
+        pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
+            Self {
+                content_length,
+                expect,
+                chunked,
+            }
+        }
+    }
 
     #[test]
     fn test_default() {

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -117,7 +117,6 @@ impl Headers {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::Headers;
     ///
     /// let mut request_header = Headers::default();
@@ -217,7 +216,6 @@ impl Headers {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::Headers;
     ///
     /// let request_headers = Headers::try_from(b"Content-Length: 55\r\n\r\n");
@@ -275,7 +273,6 @@ impl MediaType {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::MediaType;
     ///
     /// assert!(MediaType::try_from(b"application/json").is_ok());
@@ -299,7 +296,6 @@ impl MediaType {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::MediaType;
     ///
     /// let media_type = MediaType::ApplicationJson;

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -534,7 +534,10 @@ mod tests {
                 b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: -55\r\n\r\n"
             )
             .unwrap_err(),
-            RequestError::InvalidHeader
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " -55".to_string()
+            ))
         );
 
         let bytes: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -3,6 +3,7 @@
 
 use std::result::Result;
 
+use crate::HttpHeaderError;
 use crate::RequestError;
 
 /// Wrapper over an HTTP Header type.
@@ -51,7 +52,9 @@ impl Header {
                 "transfer-encoding" => Ok(Self::TransferEncoding),
                 "server" => Ok(Self::Server),
                 "accept" => Ok(Self::Accept),
-                _ => Err(RequestError::InvalidHeader),
+                invalid_key => Err(RequestError::HeaderError(HttpHeaderError::UnsupportedName(
+                    invalid_key.to_string(),
+                ))),
             }
         } else {
             Err(RequestError::InvalidRequest)
@@ -129,7 +132,9 @@ impl Headers {
             Ok(headers_str) => {
                 let entry = headers_str.splitn(2, ':').collect::<Vec<&str>>();
                 if entry.len() != 2 {
-                    return Err(RequestError::InvalidHeader);
+                    return Err(RequestError::HeaderError(HttpHeaderError::InvalidFormat(
+                        entry[0].to_string(),
+                    )));
                 }
                 if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
                     match head {
@@ -138,12 +143,22 @@ impl Headers {
                                 self.content_length = content_length;
                                 Ok(())
                             }
-                            Err(_) => Err(RequestError::InvalidHeader),
+                            Err(_) => {
+                                Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                )))
+                            }
                         },
                         Header::ContentType => {
                             match MediaType::try_from(entry[1].trim().as_bytes()) {
                                 Ok(_) => Ok(()),
-                                Err(_) => Err(RequestError::UnsupportedHeader),
+                                Err(_) => Err(RequestError::HeaderError(
+                                    HttpHeaderError::UnsupportedValue(
+                                        entry[0].to_string(),
+                                        entry[1].to_string(),
+                                    ),
+                                )),
                             }
                         }
                         Header::Accept => match MediaType::try_from(entry[1].trim().as_bytes()) {
@@ -151,30 +166,52 @@ impl Headers {
                                 self.accept = accept_type;
                                 Ok(())
                             }
-                            Err(_) => Err(RequestError::UnsupportedHeader),
+                            Err(_) => Err(RequestError::HeaderError(
+                                HttpHeaderError::UnsupportedValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                ),
+                            )),
                         },
                         Header::TransferEncoding => match entry[1].trim() {
                             "chunked" => {
                                 self.chunked = true;
                                 Ok(())
                             }
-                            "identity; q=0" => Err(RequestError::InvalidHeader),
-                            _ => Err(RequestError::UnsupportedHeader),
+                            "identity" => Ok(()),
+                            _ => Err(RequestError::HeaderError(
+                                HttpHeaderError::UnsupportedValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                ),
+                            )),
                         },
                         Header::Expect => match entry[1].trim() {
                             "100-continue" => {
                                 self.expect = true;
                                 Ok(())
                             }
-                            _ => Err(RequestError::InvalidHeader),
+                            _ => Err(RequestError::HeaderError(
+                                HttpHeaderError::UnsupportedValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                ),
+                            )),
                         },
                         Header::Server => Ok(()),
                     }
                 } else {
-                    Err(RequestError::UnsupportedHeader)
+                    Err(RequestError::HeaderError(
+                        HttpHeaderError::UnsupportedValue(
+                            entry[0].to_string(),
+                            entry[1].to_string(),
+                        ),
+                    ))
                 }
             }
-            _ => Err(RequestError::InvalidHeader),
+            Err(utf8_err) => Err(RequestError::HeaderError(
+                HttpHeaderError::InvalidUtf8String(utf8_err),
+            )),
         }
     }
 
@@ -231,7 +268,10 @@ impl Headers {
                     break;
                 }
                 match headers.parse_header_line(header_line.as_bytes()) {
-                    Ok(_) | Err(RequestError::UnsupportedHeader) => continue,
+                    Ok(_)
+                    | Err(RequestError::HeaderError(HttpHeaderError::UnsupportedValue(_, _))) => {
+                        continue
+                    }
                     Err(e) => return Err(e),
                 };
             }
@@ -411,19 +451,29 @@ mod tests {
         // Invalid header syntax.
         assert_eq!(
             header.parse_header_line(b"Expect"),
-            Err(RequestError::InvalidHeader)
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidFormat(
+                "Expect".to_string()
+            )))
         );
 
         // Invalid content length.
         assert_eq!(
             header.parse_header_line(b"Content-Length: five"),
-            Err(RequestError::InvalidHeader)
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " five".to_string()
+            )))
         );
 
         // Invalid transfer encoding.
         assert_eq!(
             header.parse_header_line(b"Transfer-Encoding: gzip"),
-            Err(RequestError::UnsupportedHeader)
+            Err(RequestError::HeaderError(
+                HttpHeaderError::UnsupportedValue(
+                    "Transfer-Encoding".to_string(),
+                    " gzip".to_string()
+                )
+            ))
         );
 
         // Invalid expect.
@@ -431,7 +481,10 @@ mod tests {
             header
                 .parse_header_line(b"Expect: 102-processing")
                 .unwrap_err(),
-            RequestError::InvalidHeader
+            RequestError::HeaderError(HttpHeaderError::UnsupportedValue(
+                "Expect".to_string(),
+                " 102-processing".to_string()
+            ))
         );
 
         // Unsupported media type.
@@ -439,14 +492,19 @@ mod tests {
             header
                 .parse_header_line(b"Content-Type: application/json-patch")
                 .unwrap_err(),
-            RequestError::UnsupportedHeader
+            RequestError::HeaderError(HttpHeaderError::UnsupportedValue(
+                "Content-Type".to_string(),
+                " application/json-patch".to_string()
+            ))
         );
 
         // Invalid input format.
         let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
         assert_eq!(
             header.parse_header_line(&input[..]).unwrap_err(),
-            RequestError::InvalidHeader
+            RequestError::HeaderError(HttpHeaderError::InvalidUtf8String(
+                String::from_utf8(input.to_vec()).unwrap_err().utf8_error()
+            ))
         );
 
         // Test valid transfer encoding.
@@ -480,7 +538,10 @@ mod tests {
         // Invalid content length.
         assert_eq!(
             header.parse_header_line(b"Content-Length: -1"),
-            Err(RequestError::InvalidHeader)
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " -1".to_string()
+            )))
         );
     }
 
@@ -530,7 +591,7 @@ mod tests {
         // Bad header.
         assert_eq!(
             Header::try_from(b"Encoding").unwrap_err(),
-            RequestError::InvalidHeader
+            RequestError::HeaderError(HttpHeaderError::UnsupportedName("encoding".to_string()))
         );
 
         // Invalid encoding.

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -21,6 +21,8 @@ pub enum Header {
     Server,
     /// Header `Accept`
     Accept,
+    /// Header `Accept-Encoding`
+    AcceptEncoding,
 }
 
 impl Header {
@@ -33,6 +35,7 @@ impl Header {
             Self::TransferEncoding => b"Transfer-Encoding",
             Self::Server => b"Server",
             Self::Accept => b"Accept",
+            Self::AcceptEncoding => b"Accept-Encoding",
         }
     }
 
@@ -52,6 +55,7 @@ impl Header {
                 "transfer-encoding" => Ok(Self::TransferEncoding),
                 "server" => Ok(Self::Server),
                 "accept" => Ok(Self::Accept),
+                "accept-encoding" => Ok(Self::AcceptEncoding),
                 invalid_key => Err(RequestError::HeaderError(HttpHeaderError::UnsupportedName(
                     invalid_key.to_string(),
                 ))),
@@ -199,6 +203,7 @@ impl Headers {
                             )),
                         },
                         Header::Server => Ok(()),
+                        Header::AcceptEncoding => Encoding::try_from(entry[1].trim().as_bytes()),
                     }
                 } else {
                     Err(RequestError::HeaderError(
@@ -283,6 +288,63 @@ impl Headers {
     /// Accept header setter.
     pub fn set_accept(&mut self, media_type: MediaType) {
         self.accept = media_type;
+    }
+}
+
+/// Wrapper over supported AcceptEncoding.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Encoding {}
+
+impl Encoding {
+    /// Parses a byte slice and checks if identity encoding is invalidated. Encoding
+    /// must be ASCII, so also UTF-8 valid.
+    ///
+    /// # Errors
+    /// `InvalidRequest` is returned when the byte stream is empty.
+    ///
+    /// `InvalidValue` is returned when the identity encoding is invalidated.
+    ///
+    /// `InvalidUtf8String` is returned when the byte stream contains invalid characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::Encoding;
+    ///
+    /// assert!(Encoding::try_from(b"deflate").is_ok());
+    /// assert!(Encoding::try_from(b"identity;q=0").is_err());
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<(), RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidRequest);
+        }
+        match std::str::from_utf8(bytes) {
+            Ok(headers_str) => {
+                let entry = headers_str.split(',').collect::<Vec<&str>>();
+
+                for encoding in entry {
+                    match encoding.trim() {
+                        "identity;q=0" => {
+                            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                                "Accept-Encoding".to_string(),
+                                encoding.to_string(),
+                            )))
+                        }
+                        "*;q=0" if !headers_str.contains("identity") => {
+                            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                                "Accept-Encoding".to_string(),
+                                encoding.to_string(),
+                            )))
+                        }
+                        _ => Ok(()),
+                    }?;
+                }
+                Ok(())
+            }
+            Err(utf8_err) => Err(RequestError::HeaderError(
+                HttpHeaderError::InvalidUtf8String(utf8_err),
+            )),
+        }
     }
 }
 
@@ -402,6 +464,42 @@ mod tests {
 
         let media_type = MediaType::PlainText;
         assert_eq!(media_type.as_str(), "text/plain");
+    }
+
+    #[test]
+    fn test_try_from_encoding() {
+        assert_eq!(
+            Encoding::try_from(b"").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        assert_eq!(
+            Encoding::try_from(b"identity;q=0").unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                "identity;q=0".to_string()
+            ))
+        );
+
+        assert!(Encoding::try_from(b"identity;q").is_ok());
+
+        assert_eq!(
+            Encoding::try_from(b"*;q=0").unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                "*;q=0".to_string()
+            ))
+        );
+
+        let bytes: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert!(Encoding::try_from(&bytes[..]).is_err());
+
+        assert!(Encoding::try_from(b"identity;q=1").is_ok());
+        assert!(Encoding::try_from(b"identity;q=0.1").is_ok());
+        assert!(Encoding::try_from(b"deflate, identity, *;q=0").is_ok());
+        assert!(Encoding::try_from(b"br").is_ok());
+        assert!(Encoding::try_from(b"compress").is_ok());
+        assert!(Encoding::try_from(b"gzip").is_ok());
     }
 
     #[test]
@@ -526,9 +624,9 @@ mod tests {
         assert!(header
             .parse_header_line(b"Accept: application/json")
             .is_ok());
-        assert!(header.accept == MediaType::ApplicationJson);
+        assert_eq!(header.accept, MediaType::ApplicationJson);
         assert!(header.parse_header_line(b"Accept: text/plain").is_ok());
-        assert!(header.accept == MediaType::PlainText);
+        assert_eq!(header.accept, MediaType::PlainText);
 
         // Test invalid accept media type.
         assert!(header
@@ -541,6 +639,17 @@ mod tests {
             Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
                 "Content-Length".to_string(),
                 " -1".to_string()
+            )))
+        );
+
+        assert!(header
+            .parse_header_line(b"Accept-Encoding: deflate")
+            .is_ok());
+        assert_eq!(
+            header.parse_header_line(b"Accept-Encoding: compress, identity;q=0"),
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                " identity;q=0".to_string()
             )))
         );
     }

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -74,7 +74,7 @@ impl Header {
 pub struct Headers {
     /// The `Content-Length` header field tells us how many bytes we need to receive
     /// from the source after the headers.
-    content_length: i32,
+    content_length: u32,
     /// The `Expect` header field is set when the headers contain the entry "Expect: 100-continue".
     /// This means that, per HTTP/1.1 specifications, we must send a response with the status code
     /// 100 after we have received the headers in order to receive the body of the request. This
@@ -134,7 +134,7 @@ impl Headers {
                 }
                 if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
                     match head {
-                        Header::ContentLength => match entry[1].trim().parse::<i32>() {
+                        Header::ContentLength => match entry[1].trim().parse::<u32>() {
                             Ok(content_length) => {
                                 self.content_length = content_length;
                                 Ok(())
@@ -180,7 +180,7 @@ impl Headers {
     }
 
     /// Returns the content length of the body.
-    pub fn content_length(&self) -> i32 {
+    pub fn content_length(&self) -> u32 {
         self.content_length
     }
 
@@ -318,7 +318,7 @@ mod tests {
     use super::*;
 
     impl Headers {
-        pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
+        pub fn new(content_length: u32, expect: bool, chunked: bool) -> Self {
             Self {
                 content_length,
                 expect,
@@ -480,6 +480,12 @@ mod tests {
         assert!(header
             .parse_header_line(b"Accept: application/json-patch")
             .is_err());
+
+        // Invalid content length.
+        assert_eq!(
+            header.parse_header_line(b"Content-Length: -1"),
+            Err(RequestError::InvalidHeader)
+        );
     }
 
     #[test]

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -32,13 +32,14 @@ impl Header {
     }
 
     fn try_from(string: &[u8]) -> Result<Self, RequestError> {
-        if let Ok(utf8_string) = String::from_utf8(string.to_vec()) {
+        if let Ok(mut utf8_string) = String::from_utf8(string.to_vec()) {
+            utf8_string.make_ascii_lowercase();
             match utf8_string.trim() {
-                "Content-Length" => Ok(Header::ContentLength),
-                "Content-Type" => Ok(Header::ContentType),
-                "Expect" => Ok(Header::Expect),
-                "Transfer-Encoding" => Ok(Header::TransferEncoding),
-                "Server" => Ok(Header::Server),
+                "content-length" => Ok(Header::ContentLength),
+                "content-type" => Ok(Header::ContentType),
+                "expect" => Ok(Header::Expect),
+                "transfer-encoding" => Ok(Header::TransferEncoding),
+                "server" => Ok(Header::Server),
                 _ => Err(RequestError::InvalidHeader),
             }
         } else {
@@ -403,5 +404,8 @@ mod tests {
 
         let header = Header::try_from(b"Transfer-Encoding").unwrap();
         assert_eq!(header.raw(), b"Transfer-Encoding");
+
+        let header = Header::try_from(b"content-length").unwrap();
+        assert_eq!(header.raw(), b"Content-Length");
     }
 }

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -21,25 +21,32 @@ pub enum Header {
 }
 
 impl Header {
+    /// Returns a byte slice representation of the object.
     pub fn raw(&self) -> &'static [u8] {
         match self {
-            Header::ContentLength => b"Content-Length",
-            Header::ContentType => b"Content-Type",
-            Header::Expect => b"Expect",
-            Header::TransferEncoding => b"Transfer-Encoding",
-            Header::Server => b"Server",
+            Self::ContentLength => b"Content-Length",
+            Self::ContentType => b"Content-Type",
+            Self::Expect => b"Expect",
+            Self::TransferEncoding => b"Transfer-Encoding",
+            Self::Server => b"Server",
         }
     }
 
+    /// Parses a byte slice into a Header structure. Header must be ASCII, so also
+    /// UTF-8 valid.
+    ///
+    /// # Errors
+    /// `InvalidRequest` is returned if slice contains invalid utf8 characters.
+    /// `InvalidHeader` is returned if unsupported header found.
     fn try_from(string: &[u8]) -> Result<Self, RequestError> {
         if let Ok(mut utf8_string) = String::from_utf8(string.to_vec()) {
             utf8_string.make_ascii_lowercase();
             match utf8_string.trim() {
-                "content-length" => Ok(Header::ContentLength),
-                "content-type" => Ok(Header::ContentType),
-                "expect" => Ok(Header::Expect),
-                "transfer-encoding" => Ok(Header::TransferEncoding),
-                "server" => Ok(Header::Server),
+                "content-length" => Ok(Self::ContentLength),
+                "content-type" => Ok(Self::ContentType),
+                "expect" => Ok(Self::Expect),
+                "transfer-encoding" => Ok(Self::TransferEncoding),
+                "server" => Ok(Self::Server),
                 _ => Err(RequestError::InvalidHeader),
             }
         } else {
@@ -75,16 +82,18 @@ pub struct Headers {
     chunked: bool,
 }
 
-impl Headers {
+impl Default for Headers {
     /// By default Requests are created with no headers.
-    pub fn default() -> Headers {
-        Headers {
-            content_length: 0,
-            expect: false,
-            chunked: false,
+    fn default() -> Self {
+        Self {
+            content_length: Default::default(),
+            expect: Default::default(),
+            chunked: Default::default(),
         }
     }
+}
 
+impl Headers {
     /// Expects one header line and parses it, updating the header structure or returning an
     /// error if the header is invalid.
     ///
@@ -94,6 +103,17 @@ impl Headers {
     /// `InvalidHeader` is returned when the parsed header is formatted incorrectly or suggests
     /// that the client is using HTTP features that we do not support in this implementation,
     /// which invalidates the request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::Headers;
+    ///
+    /// let mut request_header = Headers::default();
+    /// assert!(request_header.parse_header_line(b"Content-Length: 24").is_ok());
+    /// assert!(request_header.parse_header_line(b"Content-Length: 24: 2").is_err());
+    /// ```
     pub fn parse_header_line(&mut self, header_line: &[u8]) -> Result<(), RequestError> {
         // Headers must be ASCII, so also UTF-8 valid.
         match std::str::from_utf8(header_line) {
@@ -104,17 +124,13 @@ impl Headers {
                 }
                 if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
                     match head {
-                        Header::ContentLength => {
-                            let try_numeric: Result<i32, std::num::ParseIntError> =
-                                std::str::FromStr::from_str(entry[1].trim());
-                            match try_numeric {
-                                Ok(content_length) if content_length >= 0 => {
-                                    self.content_length = content_length;
-                                    Ok(())
-                                }
-                                _ => Err(RequestError::InvalidHeader),
+                        Header::ContentLength => match entry[1].trim().parse::<i32>() {
+                            Ok(content_length) => {
+                                self.content_length = content_length;
+                                Ok(())
                             }
-                        }
+                            Err(_) => Err(RequestError::InvalidHeader),
+                        },
                         Header::ContentType => {
                             match MediaType::try_from(entry[1].trim().as_bytes()) {
                                 Ok(_) => Ok(()),
@@ -165,7 +181,7 @@ impl Headers {
 
     #[cfg(test)]
     pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
-        Headers {
+        Self {
             content_length,
             expect,
             chunked,
@@ -196,7 +212,7 @@ impl Headers {
     pub fn try_from(bytes: &[u8]) -> Result<Headers, RequestError> {
         // Headers must be ASCII, so also UTF-8 valid.
         if let Ok(text) = std::str::from_utf8(bytes) {
-            let mut headers = Headers::default();
+            let mut headers = Self::default();
 
             let header_lines = text.split("\r\n");
             for header_line in header_lines {
@@ -224,30 +240,57 @@ pub enum MediaType {
 }
 
 impl Default for MediaType {
+    /// Default value for MediaType is application/json
     fn default() -> Self {
-        MediaType::ApplicationJson
+        Self::ApplicationJson
     }
 }
 
 impl MediaType {
-    fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+    /// Parses a byte slice into a MediaType structure for a HTTP request. MediaType
+    /// must be ASCII, so also UTF-8 valid.
+    ///
+    /// # Errors
+    /// The function returns `InvalidRequest` when parsing the byte stream fails or
+    /// unsupported MediaType found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::MediaType;
+    ///
+    /// assert!(MediaType::try_from(b"application/json").is_ok());
+    /// assert!(MediaType::try_from(b"application/json2").is_err());
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
         if bytes.is_empty() {
             return Err(RequestError::InvalidRequest);
         }
         let utf8_slice =
             String::from_utf8(bytes.to_vec()).map_err(|_| RequestError::InvalidRequest)?;
         match utf8_slice.as_str().trim() {
-            "text/plain" => Ok(MediaType::PlainText),
-            "application/json" => Ok(MediaType::ApplicationJson),
+            "text/plain" => Ok(Self::PlainText),
+            "application/json" => Ok(Self::ApplicationJson),
             _ => Err(RequestError::InvalidRequest),
         }
     }
 
     /// Returns a static string representation of the object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::MediaType;
+    ///
+    /// let media_type = MediaType::ApplicationJson;
+    /// assert_eq!(media_type.as_str(), "application/json");
+    /// ```
     pub fn as_str(self) -> &'static str {
         match self {
-            MediaType::PlainText => "text/plain",
-            MediaType::ApplicationJson => "application/json",
+            Self::PlainText => "text/plain",
+            Self::ApplicationJson => "application/json",
         }
     }
 }

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -128,7 +128,7 @@ impl Headers {
         // Headers must be ASCII, so also UTF-8 valid.
         match std::str::from_utf8(header_line) {
             Ok(headers_str) => {
-                let entry = headers_str.split(": ").collect::<Vec<&str>>();
+                let entry = headers_str.splitn(2, ':').collect::<Vec<&str>>();
                 if entry.len() != 2 {
                     return Err(RequestError::InvalidHeader);
                 }
@@ -378,9 +378,10 @@ mod tests {
         assert_eq!(headers.content_length, 55);
         assert_eq!(headers.accept, MediaType::ApplicationJson);
 
-        // Valid headers.
+        // Valid headers. (${HEADER_NAME} : WHITESPACE ${HEADER_VALUE})
+        // Any number of whitespace characters should be accepted including zero.
         let headers =  Headers::try_from(
-            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nAccept: text/plain\r\nContent-Length: 49\r\n\r\n"
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nAccept:text/plain\r\nContent-Length:   49\r\n\r\n"
         )
             .unwrap();
         assert_eq!(headers.content_length, 49);
@@ -479,6 +480,47 @@ mod tests {
         assert!(header
             .parse_header_line(b"Accept: application/json-patch")
             .is_err());
+    }
+
+    #[test]
+    fn test_parse_header_whitespace() {
+        let mut header = Headers::default();
+        // Test that any number of whitespace characters are accepted before the header value.
+        // For Content-Length
+        assert!(header.parse_header_line(b"Content-Length:24").is_ok());
+        assert!(header.parse_header_line(b"Content-Length:   24").is_ok());
+
+        // For ContentType
+        assert!(header
+            .parse_header_line(b"Content-Type:application/json")
+            .is_ok());
+        assert!(header
+            .parse_header_line(b"Content-Type:    application/json")
+            .is_ok());
+
+        // For Accept
+        assert!(header.parse_header_line(b"Accept:application/json").is_ok());
+        assert!(header
+            .parse_header_line(b"Accept:  application/json")
+            .is_ok());
+
+        // For Transfer-Encoding
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding:chunked")
+            .is_ok());
+        assert!(header.chunked());
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding:    chunked")
+            .is_ok());
+        assert!(header.chunked());
+
+        // For Server
+        assert!(header.parse_header_line(b"Server:xxx.yyy.zzz").is_ok());
+        assert!(header.parse_header_line(b"Server:   xxx.yyy.zzz").is_ok());
+
+        // For Expect
+        assert!(header.parse_header_line(b"Expect:100-continue").is_ok());
+        assert!(header.parse_header_line(b"Expect:    100-continue").is_ok());
     }
 
     #[test]

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -18,6 +18,8 @@ pub enum Header {
     TransferEncoding,
     /// Header `Server`.
     Server,
+    /// Header `Accept`
+    Accept,
 }
 
 impl Header {
@@ -29,6 +31,7 @@ impl Header {
             Self::Expect => b"Expect",
             Self::TransferEncoding => b"Transfer-Encoding",
             Self::Server => b"Server",
+            Self::Accept => b"Accept",
         }
     }
 
@@ -47,6 +50,7 @@ impl Header {
                 "expect" => Ok(Self::Expect),
                 "transfer-encoding" => Ok(Self::TransferEncoding),
                 "server" => Ok(Self::Server),
+                "accept" => Ok(Self::Accept),
                 _ => Err(RequestError::InvalidHeader),
             }
         } else {
@@ -80,6 +84,9 @@ pub struct Headers {
     /// server must support it. It is useful only when receiving the body of the request and should
     /// be known immediately after parsing the headers.
     chunked: bool,
+    /// `Accept` header might be used by HTTP clients to enforce server responses with content
+    /// formatted in a specific way.
+    accept: MediaType,
 }
 
 impl Default for Headers {
@@ -89,6 +96,9 @@ impl Default for Headers {
             content_length: Default::default(),
             expect: Default::default(),
             chunked: Default::default(),
+            // The default `Accept` media type is plain text. This is inclusive enough
+            // for structured and unstructured text.
+            accept: MediaType::PlainText,
         }
     }
 }
@@ -137,6 +147,13 @@ impl Headers {
                                 Err(_) => Err(RequestError::UnsupportedHeader),
                             }
                         }
+                        Header::Accept => match MediaType::try_from(entry[1].trim().as_bytes()) {
+                            Ok(accept_type) => {
+                                self.accept = accept_type;
+                                Ok(())
+                            }
+                            Err(_) => Err(RequestError::UnsupportedHeader),
+                        },
                         Header::TransferEncoding => match entry[1].trim() {
                             "chunked" => {
                                 self.chunked = true;
@@ -179,6 +196,11 @@ impl Headers {
         self.expect
     }
 
+    /// Returns the `Accept` header `MediaType`.
+    pub fn accept(&self) -> MediaType {
+        self.accept
+    }
+
     /// Parses a byte slice into a Headers structure for a HTTP request.
     ///
     /// The byte slice is expected to have the following format: </br>
@@ -218,6 +240,11 @@ impl Headers {
             return Ok(headers);
         }
         Err(RequestError::InvalidRequest)
+    }
+
+    /// Accept header setter.
+    pub fn set_accept(&mut self, media_type: MediaType) {
+        self.accept = media_type;
     }
 }
 
@@ -296,6 +323,7 @@ mod tests {
                 content_length,
                 expect,
                 chunked,
+                accept: MediaType::PlainText,
             }
         }
     }
@@ -343,14 +371,27 @@ mod tests {
     #[test]
     fn test_try_from_headers() {
         // Valid headers.
-        assert_eq!(
-            Headers::try_from(
-                b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: 55\r\n\r\n"
-            )
-            .unwrap()
-            .content_length,
-            55
-        );
+        let headers =  Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nAccept: application/json\r\nContent-Length: 55\r\n\r\n"
+        )
+            .unwrap();
+        assert_eq!(headers.content_length, 55);
+        assert_eq!(headers.accept, MediaType::ApplicationJson);
+
+        // Valid headers.
+        let headers =  Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nAccept: text/plain\r\nContent-Length: 49\r\n\r\n"
+        )
+            .unwrap();
+        assert_eq!(headers.content_length, 49);
+        assert_eq!(headers.accept, MediaType::PlainText);
+
+        // Valid headers.
+        let headers = Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: 29\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(headers.content_length, 29);
 
         // Valid headers.
         assert_eq!(
@@ -425,6 +466,19 @@ mod tests {
         assert!(header
             .parse_header_line(b"Content-Type: application/json")
             .is_ok());
+
+        // Test valid accept media type.
+        assert!(header
+            .parse_header_line(b"Accept: application/json")
+            .is_ok());
+        assert!(header.accept == MediaType::ApplicationJson);
+        assert!(header.parse_header_line(b"Accept: text/plain").is_ok());
+        assert!(header.accept == MediaType::PlainText);
+
+        // Test invalid accept media type.
+        assert!(header
+            .parse_header_line(b"Accept: application/json-patch")
+            .is_err());
     }
 
     #[test]
@@ -451,5 +505,8 @@ mod tests {
 
         let header = Header::try_from(b"content-length").unwrap();
         assert_eq!(header.raw(), b"Content-Length");
+
+        let header = Header::try_from(b"Accept").unwrap();
+        assert_eq!(header.raw(), b"Accept");
     }
 }

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -3,7 +3,7 @@
 
 use std::result::Result;
 
-use super::RequestError;
+use crate::RequestError;
 
 /// Wrapper over an HTTP Header type.
 #[derive(Debug, Eq, Hash, PartialEq)]

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -432,6 +432,7 @@ mod tests {
         assert_eq!(headers.content_length(), 0);
         assert_eq!(headers.chunked(), false);
         assert_eq!(headers.expect(), false);
+        assert_eq!(headers.accept(), MediaType::PlainText);
     }
 
     #[test]
@@ -725,5 +726,14 @@ mod tests {
 
         let header = Header::try_from(b"Accept").unwrap();
         assert_eq!(header.raw(), b"Accept");
+    }
+
+    #[test]
+    fn test_set_accept() {
+        let mut headers = Headers::default();
+        assert_eq!(headers.accept(), MediaType::PlainText);
+
+        headers.set_accept(MediaType::ApplicationJson);
+        assert_eq!(headers.accept(), MediaType::ApplicationJson);
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Display, Error, Formatter};
+use std::str::Utf8Error;
 
 pub mod headers;
 
@@ -11,6 +12,55 @@ pub mod ascii {
     pub const LF: u8 = b'\n';
     pub const SP: u8 = b' ';
     pub const CRLF_LEN: usize = 2;
+}
+
+///Errors associated with a header that is invalid.
+#[derive(Debug, PartialEq)]
+pub enum HttpHeaderError {
+    /// The content length specified is longer than the limit imposed by Micro Http.
+    SizeLimitExceeded(String),
+    /// The header specified is not supported.
+    UnsupportedName(String),
+    /// The value for the specified header is not supported.
+    UnsupportedValue(String, String),
+    /// The specified header contains illegal characters.
+    InvalidUtf8String(Utf8Error),
+    /// The requested feature is not currently supported.
+    UnsupportedFeature(String, String),
+    /// The header is misformatted.
+    InvalidFormat(String),
+    ///The value specified is not valid.
+    InvalidValue(String, String),
+}
+
+impl Display for HttpHeaderError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            Self::SizeLimitExceeded(inner) => {
+                write!(f, "Invalid content length. Header: {}", inner)
+            }
+            Self::UnsupportedName(inner) => write!(f, "Unsupported header name. Key: {}", inner),
+            Self::UnsupportedValue(header_key, header_value) => write!(
+                f,
+                "Unsupported value. Key:{}; Value:{}",
+                header_key, header_value
+            ),
+            Self::InvalidUtf8String(header_key) => {
+                write!(f, "Header contains invalid characters. Key: {}", header_key)
+            }
+            Self::UnsupportedFeature(header_key, header_value) => write!(
+                f,
+                "Unsupported feature. Key: {}; Value: {}",
+                header_key, header_value
+            ),
+            Self::InvalidFormat(header_key) => {
+                write!(f, "Header is incorrectly formatted. Key: {}", header_key)
+            }
+            Self::InvalidValue(header_name, value) => {
+                write!(f, "Invalid value. Key:{}; Value:{}", header_name, value)
+            }
+        }
+    }
 }
 
 /// Errors associated with parsing the HTTP Request from a u8 slice.
@@ -26,10 +76,8 @@ pub enum RequestError {
     InvalidUri(&'static str),
     /// The HTTP Version in the Request is not supported or it is invalid.
     InvalidHttpVersion(&'static str),
-    /// The header specified may be valid, but is not supported by this HTTP implementation.
-    UnsupportedHeader,
-    /// Header specified is invalid.
-    InvalidHeader,
+    /// Header specified is either invalid or not supported by this HTTP implementation.
+    HeaderError(HttpHeaderError),
     /// The Request is invalid and cannot be served.
     InvalidRequest,
     /// Overflow occurred when parsing a request.
@@ -52,8 +100,7 @@ impl Display for RequestError {
             Self::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
             Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
             Self::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
-            Self::UnsupportedHeader => write!(f, "Unsupported header."),
-            Self::InvalidHeader => write!(f, "Invalid header."),
+            Self::HeaderError(inner) => write!(f, "Invalid header. Reason: {}", inner),
             Self::InvalidRequest => write!(f, "Invalid request."),
             Self::Overflow => write!(f, "Overflow occurred when parsing a request."),
             Self::Underflow => write!(f, "Underflow occurred when parsing a request."),
@@ -362,10 +409,6 @@ mod tests {
             "No request was pending while the request headers were being parsed."
         );
         assert_eq!(
-            format!("{}", RequestError::InvalidHeader),
-            "Invalid header."
-        );
-        assert_eq!(
             format!("{}", RequestError::InvalidHttpMethod("test")),
             "Invalid HTTP Method: test"
         );
@@ -389,9 +432,60 @@ mod tests {
             format!("{}", RequestError::Underflow),
             "Underflow occurred when parsing a request."
         );
+    }
+
+    #[test]
+    fn test_display_header_error() {
         assert_eq!(
-            format!("{}", RequestError::UnsupportedHeader),
-            "Unsupported header."
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::SizeLimitExceeded("test".to_string()))
+            ),
+            "Invalid header. Reason: Invalid content length. Header: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedName("test".to_string()))
+            ),
+            "Invalid header. Reason: Unsupported header name. Key: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedValue(
+                    "test".to_string(),
+                    "test".to_string()
+                ))
+            ),
+            "Invalid header. Reason: Unsupported value. Key:test; Value:test"
+        );
+        let value = String::from_utf8(vec![0, 159]);
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::InvalidUtf8String(
+                    value.unwrap_err().utf8_error()
+                ))
+            ),
+            "Invalid header. Reason: Header contains invalid characters. Key: invalid utf-8 sequence of 1 bytes from index 1"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedFeature(
+                    "test".to_string(),
+                    "test".to_string()
+                ))
+            ),
+            "Invalid header. Reason: Unsupported feature. Key: test; Value: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::InvalidFormat("test".to_string()))
+            ),
+            "Invalid header. Reason: Header is incorrectly formatted. Key: test"
         );
     }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -131,7 +131,6 @@ impl Display for ServerError {
 ///
 /// ## Examples
 /// ```
-/// extern crate micro_http;
 /// use micro_http::Body;
 /// let body = Body::new("This is a test body.".to_string());
 /// assert_eq!(body.raw(), b"This is a test body.");
@@ -231,7 +230,6 @@ impl Method {
 ///
 /// # Examples
 /// ```
-/// extern crate micro_http;
 /// use micro_http::Version;
 /// let version = Version::try_from(b"HTTP/1.1");
 /// assert!(version.is_ok());

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -142,7 +142,7 @@ impl Body {
 }
 
 /// Supported HTTP Methods.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Method {
     /// GET Method.
     Get,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -33,12 +33,12 @@ pub enum RequestError {
 impl Display for RequestError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            RequestError::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
-            RequestError::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
-            RequestError::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
-            RequestError::UnsupportedHeader => write!(f, "Unsupported header."),
-            RequestError::InvalidHeader => write!(f, "Invalid header."),
-            RequestError::InvalidRequest => write!(f, "Invalid request."),
+            Self::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
+            Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
+            Self::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
+            Self::UnsupportedHeader => write!(f, "Unsupported header."),
+            Self::InvalidHeader => write!(f, "Invalid header."),
+            Self::InvalidRequest => write!(f, "Invalid request."),
         }
     }
 }
@@ -59,10 +59,10 @@ pub enum ConnectionError {
 impl Display for ConnectionError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            ConnectionError::ParseError(inner) => write!(f, "Parsing error: {}", inner),
-            ConnectionError::StreamError(inner) => write!(f, "Stream error: {}", inner),
-            ConnectionError::ConnectionClosed => write!(f, "Connection closed."),
-            ConnectionError::InvalidWrite => write!(f, "Invalid write attempt."),
+            Self::ParseError(inner) => write!(f, "Parsing error: {}", inner),
+            Self::StreamError(inner) => write!(f, "Stream error: {}", inner),
+            Self::ConnectionClosed => write!(f, "Connection closed."),
+            Self::InvalidWrite => write!(f, "Invalid write attempt."),
         }
     }
 }
@@ -96,9 +96,9 @@ pub enum ServerError {
 impl Display for ServerError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            ServerError::IOError(inner) => write!(f, "IO error: {}", inner),
-            ServerError::ConnectionError(inner) => write!(f, "Connection error: {}", inner),
-            ServerError::ServerFull => write!(f, "Server is full."),
+            Self::IOError(inner) => write!(f, "IO error: {}", inner),
+            Self::ConnectionError(inner) => write!(f, "Connection error: {}", inner),
+            Self::ServerFull => write!(f, "Server is full."),
         }
     }
 }
@@ -122,7 +122,7 @@ pub struct Body {
 impl Body {
     /// Creates a new `Body` from a `String` input.
     pub fn new<T: Into<Vec<u8>>>(body: T) -> Self {
-        Body { body: body.into() }
+        Self { body: body.into() }
     }
 
     /// Returns the body as an `u8 slice`.
@@ -165,7 +165,7 @@ impl Method {
     /// an error, but when using the input b"GET", it returns Method::Get.
     ///
     /// # Errors
-    /// Returns `RequestError` if the method specified by `bytes` is unsupported.
+    /// `InvalidHttpMethod` is returned if the specified HTTP method is unsupported.
     pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
         match bytes {
             b"GET" => Ok(Method::Get),
@@ -223,12 +223,19 @@ pub enum Version {
     Http11,
 }
 
+impl Default for Version {
+    /// Returns the default HTTP version = HTTP/1.1.
+    fn default() -> Self {
+        Self::Http11
+    }
+}
+
 impl Version {
     /// HTTP Version as an `u8 slice`.
     pub fn raw(self) -> &'static [u8] {
         match self {
-            Version::Http10 => b"HTTP/1.0",
-            Version::Http11 => b"HTTP/1.1",
+            Self::Http10 => b"HTTP/1.0",
+            Self::Http11 => b"HTTP/1.1",
         }
     }
 
@@ -238,20 +245,15 @@ impl Version {
     /// The version is case sensitive and the accepted input is upper case.
     ///
     /// # Errors
-    /// Returns a `RequestError` when the version is not supported.
+    /// Returns a `InvalidHttpVersion` when the HTTP version is not supported.
     pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
         match bytes {
-            b"HTTP/1.0" => Ok(Version::Http10),
-            b"HTTP/1.1" => Ok(Version::Http11),
+            b"HTTP/1.0" => Ok(Self::Http10),
+            b"HTTP/1.1" => Ok(Self::Http11),
             _ => Err(RequestError::InvalidHttpVersion(
                 "Unsupported HTTP version.",
             )),
         }
-    }
-
-    /// Returns the default HTTP version = HTTP/1.1.
-    pub fn default() -> Self {
-        Version::Http11
     }
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -28,6 +28,10 @@ pub enum RequestError {
     InvalidHeader,
     /// The Request is invalid and cannot be served.
     InvalidRequest,
+    /// Overflow occurred when parsing a request.
+    Overflow,
+    /// Underflow occurred when parsing a request.
+    Underflow,
 }
 
 impl Display for RequestError {
@@ -39,6 +43,8 @@ impl Display for RequestError {
             Self::UnsupportedHeader => write!(f, "Unsupported header."),
             Self::InvalidHeader => write!(f, "Invalid header."),
             Self::InvalidRequest => write!(f, "Invalid request."),
+            Self::Overflow => write!(f, "Overflow occurred when parsing a request."),
+            Self::Underflow => write!(f, "Underflow occurred when parsing a request."),
         }
     }
 }
@@ -91,6 +97,10 @@ pub enum ServerError {
     ConnectionError(ConnectionError),
     /// Server maximum capacity has been reached.
     ServerFull,
+    /// Overflow occured while processing messages.
+    Overflow,
+    /// Underflow occured while processing mesagges.
+    Underflow,
 }
 
 impl Display for ServerError {
@@ -99,6 +109,8 @@ impl Display for ServerError {
             Self::IOError(inner) => write!(f, "IO error: {}", inner),
             Self::ConnectionError(inner) => write!(f, "Connection error: {}", inner),
             Self::ServerFull => write!(f, "Server is full."),
+            Self::Overflow => write!(f, "Overflow occured while processing messages."),
+            Self::Underflow => write!(f, "Underflow occured while processing messages."),
         }
     }
 }
@@ -265,9 +277,11 @@ mod tests {
         fn eq(&self, other: &Self) -> bool {
             use self::ConnectionError::*;
             match (self, other) {
-                (ParseError(_), ParseError(_)) => true,
+                (ParseError(ref e), ParseError(ref other_e)) => e.eq(other_e),
                 (ConnectionClosed, ConnectionClosed) => true,
-                (StreamError(_), StreamError(_)) => true,
+                (StreamError(ref e), StreamError(ref other_e)) => {
+                    format!("{}", e).eq(&format!("{}", other_e))
+                }
                 (InvalidWrite, InvalidWrite) => true,
                 _ => false,
             }
@@ -330,28 +344,36 @@ mod tests {
     #[test]
     fn test_display_request_error() {
         assert_eq!(
-            format!("{}", RequestError::InvalidHttpMethod("test")),
-            "Invalid HTTP Method: test"
+            format!("{}", RequestError::InvalidHeader),
+            "Invalid header."
         );
         assert_eq!(
-            format!("{}", RequestError::InvalidUri("test")),
-            "Invalid URI: test"
+            format!("{}", RequestError::InvalidHttpMethod("test")),
+            "Invalid HTTP Method: test"
         );
         assert_eq!(
             format!("{}", RequestError::InvalidHttpVersion("test")),
             "Invalid HTTP Version: test"
         );
         assert_eq!(
-            format!("{}", RequestError::InvalidHeader),
-            "Invalid header."
+            format!("{}", RequestError::InvalidRequest),
+            "Invalid request."
+        );
+        assert_eq!(
+            format!("{}", RequestError::InvalidUri("test")),
+            "Invalid URI: test"
+        );
+        assert_eq!(
+            format!("{}", RequestError::Overflow),
+            "Overflow occurred when parsing a request."
+        );
+        assert_eq!(
+            format!("{}", RequestError::Underflow),
+            "Underflow occurred when parsing a request."
         );
         assert_eq!(
             format!("{}", RequestError::UnsupportedHeader),
             "Unsupported header."
-        );
-        assert_eq!(
-            format!("{}", RequestError::InvalidRequest),
-            "Invalid request."
         );
     }
 
@@ -397,6 +419,14 @@ mod tests {
                 ServerError::IOError(std::io::Error::from_raw_os_error(11))
             ),
             "IO error: Resource temporarily unavailable (os error 11)"
+        );
+        assert_eq!(
+            format!("{}", ServerError::Overflow),
+            "Overflow occured while processing messages."
+        );
+        assert_eq!(
+            format!("{}", ServerError::Underflow),
+            "Underflow occured while processing messages."
         );
     }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -134,6 +134,7 @@ impl Display for ConnectionError {
 
 /// Errors pertaining to `HttpRoute`.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum RouteError {
     /// Handler for http routing path already exists.
     HandlerExist(String),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -17,48 +17,48 @@ pub mod ascii {
 ///Errors associated with a header that is invalid.
 #[derive(Debug, PartialEq)]
 pub enum HttpHeaderError {
+    /// The header is misformatted.
+    InvalidFormat(String),
+    /// The specified header contains illegal characters.
+    InvalidUtf8String(Utf8Error),
+    ///The value specified is not valid.
+    InvalidValue(String, String),
     /// The content length specified is longer than the limit imposed by Micro Http.
     SizeLimitExceeded(String),
+    /// The requested feature is not currently supported.
+    UnsupportedFeature(String, String),
     /// The header specified is not supported.
     UnsupportedName(String),
     /// The value for the specified header is not supported.
     UnsupportedValue(String, String),
-    /// The specified header contains illegal characters.
-    InvalidUtf8String(Utf8Error),
-    /// The requested feature is not currently supported.
-    UnsupportedFeature(String, String),
-    /// The header is misformatted.
-    InvalidFormat(String),
-    ///The value specified is not valid.
-    InvalidValue(String, String),
 }
 
 impl Display for HttpHeaderError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            Self::SizeLimitExceeded(inner) => {
-                write!(f, "Invalid content length. Header: {}", inner)
+            Self::InvalidFormat(header_key) => {
+                write!(f, "Header is incorrectly formatted. Key: {}", header_key)
             }
-            Self::UnsupportedName(inner) => write!(f, "Unsupported header name. Key: {}", inner),
-            Self::UnsupportedValue(header_key, header_value) => write!(
-                f,
-                "Unsupported value. Key:{}; Value:{}",
-                header_key, header_value
-            ),
             Self::InvalidUtf8String(header_key) => {
                 write!(f, "Header contains invalid characters. Key: {}", header_key)
+            }
+            Self::InvalidValue(header_name, value) => {
+                write!(f, "Invalid value. Key:{}; Value:{}", header_name, value)
+            }
+            Self::SizeLimitExceeded(inner) => {
+                write!(f, "Invalid content length. Header: {}", inner)
             }
             Self::UnsupportedFeature(header_key, header_value) => write!(
                 f,
                 "Unsupported feature. Key: {}; Value: {}",
                 header_key, header_value
             ),
-            Self::InvalidFormat(header_key) => {
-                write!(f, "Header is incorrectly formatted. Key: {}", header_key)
-            }
-            Self::InvalidValue(header_name, value) => {
-                write!(f, "Invalid value. Key:{}; Value:{}", header_name, value)
-            }
+            Self::UnsupportedName(inner) => write!(f, "Unsupported header name. Key: {}", inner),
+            Self::UnsupportedValue(header_key, header_value) => write!(
+                f,
+                "Unsupported value. Key:{}; Value:{}",
+                header_key, header_value
+            ),
         }
     }
 }
@@ -68,18 +68,18 @@ impl Display for HttpHeaderError {
 pub enum RequestError {
     /// No request was pending while the request body was being parsed.
     BodyWithoutPendingRequest,
+    /// Header specified is either invalid or not supported by this HTTP implementation.
+    HeaderError(HttpHeaderError),
     /// No request was pending while the request headers were being parsed.
     HeadersWithoutPendingRequest,
     /// The HTTP Method is not supported or it is invalid.
     InvalidHttpMethod(&'static str),
-    /// Request URI is invalid.
-    InvalidUri(&'static str),
     /// The HTTP Version in the Request is not supported or it is invalid.
     InvalidHttpVersion(&'static str),
-    /// Header specified is either invalid or not supported by this HTTP implementation.
-    HeaderError(HttpHeaderError),
     /// The Request is invalid and cannot be served.
     InvalidRequest,
+    /// Request URI is invalid.
+    InvalidUri(&'static str),
     /// Overflow occurred when parsing a request.
     Overflow,
     /// Underflow occurred when parsing a request.
@@ -93,15 +93,15 @@ impl Display for RequestError {
                 f,
                 "No request was pending while the request body was being parsed."
             ),
+            Self::HeaderError(inner) => write!(f, "Invalid header. Reason: {}", inner),
             Self::HeadersWithoutPendingRequest => write!(
                 f,
                 "No request was pending while the request headers were being parsed."
             ),
             Self::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
-            Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
             Self::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
-            Self::HeaderError(inner) => write!(f, "Invalid header. Reason: {}", inner),
             Self::InvalidRequest => write!(f, "Invalid request."),
+            Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
             Self::Overflow => write!(f, "Overflow occurred when parsing a request."),
             Self::Underflow => write!(f, "Underflow occurred when parsing a request."),
         }
@@ -111,23 +111,23 @@ impl Display for RequestError {
 /// Errors associated with a HTTP Connection.
 #[derive(Debug)]
 pub enum ConnectionError {
-    /// The request parsing has failed.
-    ParseError(RequestError),
-    /// Could not perform a stream operation successfully.
-    StreamError(std::io::Error),
     /// Attempted to read or write on a closed connection.
     ConnectionClosed,
     /// Attempted to write on a stream when there was nothing to write.
     InvalidWrite,
+    /// The request parsing has failed.
+    ParseError(RequestError),
+    /// Could not perform a stream operation successfully.
+    StreamError(std::io::Error),
 }
 
 impl Display for ConnectionError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            Self::ParseError(inner) => write!(f, "Parsing error: {}", inner),
-            Self::StreamError(inner) => write!(f, "Stream error: {}", inner),
             Self::ConnectionClosed => write!(f, "Connection closed."),
             Self::InvalidWrite => write!(f, "Invalid write attempt."),
+            Self::ParseError(inner) => write!(f, "Parsing error: {}", inner),
+            Self::StreamError(inner) => write!(f, "Stream error: {}", inner),
         }
     }
 }
@@ -151,14 +151,14 @@ impl Display for RouteError {
 /// Errors pertaining to `HttpServer`.
 #[derive(Debug)]
 pub enum ServerError {
-    /// Epoll operations failed.
-    IOError(std::io::Error),
     /// Error from one of the connections.
     ConnectionError(ConnectionError),
-    /// Server maximum capacity has been reached.
-    ServerFull,
+    /// Epoll operations failed.
+    IOError(std::io::Error),
     /// Overflow occured while processing messages.
     Overflow,
+    /// Server maximum capacity has been reached.
+    ServerFull,
     /// Underflow occured while processing mesagges.
     Underflow,
 }
@@ -166,10 +166,10 @@ pub enum ServerError {
 impl Display for ServerError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            Self::IOError(inner) => write!(f, "IO error: {}", inner),
             Self::ConnectionError(inner) => write!(f, "Connection error: {}", inner),
-            Self::ServerFull => write!(f, "Server is full."),
+            Self::IOError(inner) => write!(f, "IO error: {}", inner),
             Self::Overflow => write!(f, "Overflow occured while processing messages."),
+            Self::ServerFull => write!(f, "Server is full."),
             Self::Underflow => write!(f, "Underflow occured while processing messages."),
         }
     }
@@ -440,9 +440,36 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
+                RequestError::HeaderError(HttpHeaderError::InvalidFormat("test".to_string()))
+            ),
+            "Invalid header. Reason: Header is incorrectly formatted. Key: test"
+        );
+        let value = String::from_utf8(vec![0, 159]);
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::InvalidUtf8String(
+                    value.unwrap_err().utf8_error()
+                ))
+            ),
+            "Invalid header. Reason: Header contains invalid characters. Key: invalid utf-8 sequence of 1 bytes from index 1"
+        );
+        assert_eq!(
+            format!(
+                "{}",
                 RequestError::HeaderError(HttpHeaderError::SizeLimitExceeded("test".to_string()))
             ),
             "Invalid header. Reason: Invalid content length. Header: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedFeature(
+                    "test".to_string(),
+                    "test".to_string()
+                ))
+            ),
+            "Invalid header. Reason: Unsupported feature. Key: test; Value: test"
         );
         assert_eq!(
             format!(
@@ -461,37 +488,14 @@ mod tests {
             ),
             "Invalid header. Reason: Unsupported value. Key:test; Value:test"
         );
-        let value = String::from_utf8(vec![0, 159]);
-        assert_eq!(
-            format!(
-                "{}",
-                RequestError::HeaderError(HttpHeaderError::InvalidUtf8String(
-                    value.unwrap_err().utf8_error()
-                ))
-            ),
-            "Invalid header. Reason: Header contains invalid characters. Key: invalid utf-8 sequence of 1 bytes from index 1"
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                RequestError::HeaderError(HttpHeaderError::UnsupportedFeature(
-                    "test".to_string(),
-                    "test".to_string()
-                ))
-            ),
-            "Invalid header. Reason: Unsupported feature. Key: test; Value: test"
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                RequestError::HeaderError(HttpHeaderError::InvalidFormat("test".to_string()))
-            ),
-            "Invalid header. Reason: Header is incorrectly formatted. Key: test"
-        );
     }
 
     #[test]
     fn test_display_connection_error() {
+        assert_eq!(
+            format!("{}", ConnectionError::ConnectionClosed),
+            "Connection closed."
+        );
         assert_eq!(
             format!(
                 "{}",
@@ -500,19 +504,15 @@ mod tests {
             "Parsing error: Invalid request."
         );
         assert_eq!(
+            format!("{}", ConnectionError::InvalidWrite),
+            "Invalid write attempt."
+        );
+        assert_eq!(
             format!(
                 "{}",
                 ConnectionError::StreamError(std::io::Error::from_raw_os_error(11))
             ),
             "Stream error: Resource temporarily unavailable (os error 11)"
-        );
-        assert_eq!(
-            format!("{}", ConnectionError::ConnectionClosed),
-            "Connection closed."
-        );
-        assert_eq!(
-            format!("{}", ConnectionError::InvalidWrite),
-            "Invalid write attempt."
         );
     }
 
@@ -525,7 +525,6 @@ mod tests {
             ),
             "Connection error: Connection closed."
         );
-        assert_eq!(format!("{}", ServerError::ServerFull), "Server is full.");
         assert_eq!(
             format!(
                 "{}",
@@ -537,6 +536,7 @@ mod tests {
             format!("{}", ServerError::Overflow),
             "Overflow occured while processing messages."
         );
+        assert_eq!(format!("{}", ServerError::ServerFull), "Server is full.");
         assert_eq!(
             format!("{}", ServerError::Underflow),
             "Underflow occured while processing messages."

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -544,6 +544,14 @@ mod tests {
     }
 
     #[test]
+    fn test_display_route_error() {
+        assert_eq!(
+            format!("{}", RouteError::HandlerExist("test".to_string())),
+            "handler for test already exists"
+        );
+    }
+
+    #[test]
     fn test_method_to_str() {
         let val = Method::Get;
         assert_eq!(val.to_str(), "GET");

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,6 +16,10 @@ pub mod ascii {
 /// Errors associated with parsing the HTTP Request from a u8 slice.
 #[derive(Debug, PartialEq)]
 pub enum RequestError {
+    /// No request was pending while the request body was being parsed.
+    BodyWithoutPendingRequest,
+    /// No request was pending while the request headers were being parsed.
+    HeadersWithoutPendingRequest,
     /// The HTTP Method is not supported or it is invalid.
     InvalidHttpMethod(&'static str),
     /// Request URI is invalid.
@@ -37,6 +41,14 @@ pub enum RequestError {
 impl Display for RequestError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
+            Self::BodyWithoutPendingRequest => write!(
+                f,
+                "No request was pending while the request body was being parsed."
+            ),
+            Self::HeadersWithoutPendingRequest => write!(
+                f,
+                "No request was pending while the request headers were being parsed."
+            ),
             Self::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
             Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
             Self::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
@@ -343,6 +355,14 @@ mod tests {
 
     #[test]
     fn test_display_request_error() {
+        assert_eq!(
+            format!("{}", RequestError::BodyWithoutPendingRequest),
+            "No request was pending while the request body was being parsed."
+        );
+        assert_eq!(
+            format!("{}", RequestError::HeadersWithoutPendingRequest),
+            "No request was pending while the request headers were being parsed."
+        );
         assert_eq!(
             format!("{}", RequestError::InvalidHeader),
             "Invalid header."

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -428,7 +428,8 @@ impl<T: Read + Write> HttpConnection<T> {
         Ok(())
     }
 
-    fn clear_write_buffer(&mut self) {
+    /// Discards all pending writes from the connection.
+    pub fn clear_write_buffer(&mut self) {
         self.response_queue.clear();
         self.response_buffer.take();
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -131,6 +131,7 @@ impl<T: Read + Write> HttpConnection<T> {
                 Err(e) => return Err(ConnectionError::StreamError(e)),
             }
         }
+        Ok(bytes_read + self.read_cursor)
     }
 
     /// Parses bytes in `buffer` for a valid request line.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -14,7 +14,7 @@ use crate::response::{Response, StatusCode};
 const BUFFER_SIZE: usize = 1024;
 
 /// Describes the state machine of an HTTP connection.
-pub(crate) enum ConnectionState {
+enum ConnectionState {
     WaitingForRequestLine,
     WaitingForHeaders,
     WaitingForBody,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,12 +5,11 @@ use std::collections::VecDeque;
 use std::io::{Read, Write};
 
 use crate::common::ascii::{CR, CRLF_LEN, LF};
-use crate::common::headers::Headers;
-use crate::common::{Body, RequestError};
+use crate::common::Body;
+pub use crate::common::{ConnectionError, RequestError};
+use crate::headers::Headers;
 use crate::request::{find, Request, RequestLine};
 use crate::response::{Response, StatusCode};
-
-pub use crate::common::ConnectionError;
 
 const BUFFER_SIZE: usize = 1024;
 
@@ -482,10 +481,11 @@ impl<T: Read + Write> HttpConnection<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use common::{Method, Version};
     use std::net::Shutdown;
     use std::os::unix::net::UnixStream;
+
+    use super::*;
+    use crate::common::{Method, Version};
 
     #[test]
     fn test_try_read_expect() {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -42,7 +42,7 @@ pub struct HttpConnection<T> {
     body_vec: Vec<u8>,
     /// Represents how many bytes from the body of the request are still
     /// to be read.
-    body_bytes_to_be_read: i32,
+    body_bytes_to_be_read: u32,
     /// A queue of all requests that have been fully received and parsed.
     parsed_requests: VecDeque<Request>,
     /// A queue of requests that are waiting to be sent.
@@ -120,18 +120,25 @@ impl<T: Read + Write> HttpConnection<T> {
     /// # Errors
     /// `StreamError` is returned if any error occurred while reading the stream.
     /// `ConnectionClosed` is returned if the client closed the connection.
+    /// `Overflow` is returned if an arithmetic overflow occurs while parsing the request.
     fn read_bytes(&mut self) -> Result<usize, ConnectionError> {
-        loop {
-            // Append new bytes to what we already have in the buffer.
-            match self.stream.read(&mut self.buffer[self.read_cursor..]) {
-                // If the read returned 0 then the client has closed the connection.
-                Ok(0) => return Err(ConnectionError::ConnectionClosed),
-                Ok(bytes_read) => return Ok(bytes_read + self.read_cursor),
-                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                Err(e) => return Err(ConnectionError::StreamError(e)),
-            }
+        if self.read_cursor >= BUFFER_SIZE {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
         }
-        Ok(bytes_read + self.read_cursor)
+        // Append new bytes to what we already have in the buffer.
+        // The slice access is safe, the index is checked above.
+        let bytes_read = self
+            .stream
+            .read(&mut self.buffer[self.read_cursor..])
+            .map_err(ConnectionError::StreamError)?;
+
+        // If the read returned 0 then the client has closed the connection.
+        if bytes_read == 0 {
+            return Err(ConnectionError::ConnectionClosed);
+        }
+        bytes_read
+            .checked_add(self.read_cursor)
+            .ok_or(ConnectionError::ParseError(RequestError::Overflow))
     }
 
     /// Parses bytes in `buffer` for a valid request line.
@@ -144,10 +151,22 @@ impl<T: Read + Write> HttpConnection<T> {
         start: &mut usize,
         end: usize,
     ) -> Result<bool, ConnectionError> {
+        if end < *start {
+            return Err(ConnectionError::ParseError(RequestError::Underflow));
+        }
+        if end > self.buffer.len() {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        // The slice access is safe because `end` is checked to be smaller than the buffer size
+        // and larger than `start`.
         match find(&self.buffer[*start..end], &[CR, LF]) {
             Some(line_end_index) => {
+                // The unchecked addition `start + line_end_index` is safe because `line_end_index`
+                // is returned by `find` and thus guaranteed to be in-bounds. This also makes the
+                // slice access safe.
                 let line = &self.buffer[*start..(*start + line_end_index)];
 
+                // The unchecked addition is safe because of the previous `find()`.
                 *start = *start + line_end_index + CRLF_LEN;
 
                 // Form the request with a valid request line, which is the bare minimum
@@ -170,7 +189,8 @@ impl<T: Read + Write> HttpConnection<T> {
                     // for the next `try_read` call to complete it.
                     // This can only happen if another request was sent before this one, as the
                     // limit for the length of a request line in this implementation is 1024 bytes.
-                    self.shift_buffer_left(*start, end);
+                    self.shift_buffer_left(*start, end)
+                        .map_err(ConnectionError::ParseError)?;
                 }
                 Ok(false)
             }
@@ -187,6 +207,13 @@ impl<T: Read + Write> HttpConnection<T> {
         line_start_index: &mut usize,
         end_cursor: usize,
     ) -> Result<bool, ConnectionError> {
+        if end_cursor > self.buffer.len() {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        if end_cursor < *line_start_index {
+            return Err(ConnectionError::ParseError(RequestError::Underflow));
+        }
+        // Safe to access the slice as the bounds are checked above.
         match find(&self.buffer[*line_start_index..end_cursor], &[CR, LF]) {
             // `line_start_index` points to the end of the most recently found CR LF
             // sequence. That means that if we found the next CR LF sequence at this index,
@@ -195,9 +222,14 @@ impl<T: Read + Write> HttpConnection<T> {
 
             // We have found the end of the header.
             Some(0) => {
-                // If our current state is `WaitingForHeaders`, it means that we already have
-                // a valid request formed from a request line, so it's safe to unwrap.
-                let request = self.pending_request.as_mut().unwrap();
+                // The current state is `WaitingForHeaders`, ensuring a valid request formed from a
+                // request line.
+                let request = self
+                    .pending_request
+                    .as_mut()
+                    .ok_or(ConnectionError::ParseError(
+                        RequestError::HeadersWithoutPendingRequest,
+                    ))?;
                 if request.headers.content_length() == 0 {
                     self.state = ConnectionState::RequestReady;
                 } else {
@@ -214,16 +246,28 @@ impl<T: Read + Write> HttpConnection<T> {
                 }
 
                 // Update the index for the next header.
-                *line_start_index += CRLF_LEN;
+                *line_start_index = line_start_index
+                    .checked_add(CRLF_LEN)
+                    .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
                 Ok(true)
             }
             // We have found the end of a header line.
             Some(relative_line_end_index) => {
-                let request = self.pending_request.as_mut().unwrap();
+                let request = self
+                    .pending_request
+                    .as_mut()
+                    .ok_or(ConnectionError::ParseError(
+                        RequestError::HeadersWithoutPendingRequest,
+                    ))?;
                 // The `line_end_index` relative to the whole buffer.
-                let line_end_index = relative_line_end_index + *line_start_index;
+                let line_end_index = relative_line_end_index
+                    .checked_add(*line_start_index)
+                    .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
 
                 // Get the line slice and parse it.
+                // The slice access is safe because `line_end_index` is a sum of `line_end_index`
+                // and something else, and `line_end_index` itself is guaranteed to be within
+                // `self.buffer`'s bounds by the `find()`.
                 let line = &self.buffer[*line_start_index..line_end_index];
                 match request.headers.parse_header_line(line) {
                     // If a header is unsupported we ignore it.
@@ -234,7 +278,9 @@ impl<T: Read + Write> HttpConnection<T> {
                 };
 
                 // Update the `line_start_index` to where we finished parsing.
-                *line_start_index = line_end_index + CRLF_LEN;
+                *line_start_index = line_end_index
+                    .checked_add(CRLF_LEN)
+                    .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
                 Ok(true)
             }
             // If we have an incomplete header line.
@@ -248,7 +294,8 @@ impl<T: Read + Write> HttpConnection<T> {
                 // Move the incomplete header line from the end of the buffer to
                 // the beginning, so that we can append the rest of the line and
                 // parse it in the next `try_read` call.
-                self.shift_buffer_left(*line_start_index, end_cursor);
+                self.shift_buffer_left(*line_start_index, end_cursor)
+                    .map_err(ConnectionError::ParseError)?;
                 Ok(false)
             }
         }
@@ -266,12 +313,21 @@ impl<T: Read + Write> HttpConnection<T> {
     ) -> Result<bool, ConnectionError> {
         // If what we have just read is not enough to complete the request and
         // there are more bytes pertaining to the body of the request.
-        if self.body_bytes_to_be_read > end_cursor as i32 - *line_start_index as i32 {
+        if end_cursor > self.buffer.len() {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        let start_to_end = end_cursor
+            .checked_sub(*line_start_index)
+            .ok_or(ConnectionError::ParseError(RequestError::Underflow))?
+            as u32;
+        if self.body_bytes_to_be_read > start_to_end {
             // Append everything that we read to our current incomplete body and update
             // `body_bytes_to_be_read`.
+            // The slice access is safe, otherwise `checked_sub` would have failed.
             self.body_vec
                 .extend_from_slice(&self.buffer[*line_start_index..end_cursor]);
-            self.body_bytes_to_be_read -= end_cursor as i32 - *line_start_index as i32;
+            // Safe to subtract directly as the `if` condition prevents underflow.
+            self.body_bytes_to_be_read -= start_to_end;
 
             // Clear the buffer and reset the starting index.
             for i in 0..BUFFER_SIZE {
@@ -283,14 +339,21 @@ impl<T: Read + Write> HttpConnection<T> {
         }
 
         // Append only the remaining necessary bytes to the body of the request.
-        self.body_vec.extend_from_slice(
-            &self.buffer
-                [*line_start_index..(*line_start_index + self.body_bytes_to_be_read as usize)],
-        );
-        *line_start_index += self.body_bytes_to_be_read as usize;
+        let line_end = line_start_index
+            .checked_add(self.body_bytes_to_be_read as usize)
+            .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
+        // The slice access is safe as `line_end` is a sum of `line_start_index` + something else.
+        self.body_vec
+            .extend_from_slice(&self.buffer[*line_start_index..line_end]);
+        *line_start_index = line_end;
         self.body_bytes_to_be_read = 0;
 
-        let request = self.pending_request.as_mut().unwrap();
+        let request = self
+            .pending_request
+            .as_mut()
+            .ok_or(ConnectionError::ParseError(
+                RequestError::BodyWithoutPendingRequest,
+            ))?;
         // If there are no more bytes to be read for this request.
         // Assign the body of the request.
         let placeholder: Vec<_> = self
@@ -372,22 +435,37 @@ impl<T: Read + Write> HttpConnection<T> {
         self.response_queue.push_back(response);
     }
 
-    fn shift_buffer_left(&mut self, line_start_index: usize, end_cursor: usize) {
+    fn shift_buffer_left(
+        &mut self,
+        line_start_index: usize,
+        end_cursor: usize,
+    ) -> Result<(), RequestError> {
+        if end_cursor > self.buffer.len() {
+            return Err(RequestError::Overflow);
+        }
         // We don't want to shift something that is already at the beginning.
+        let delta_bytes = end_cursor
+            .checked_sub(line_start_index)
+            .ok_or(RequestError::Underflow)?;
         if line_start_index != 0 {
             // Move the bytes from `line_start_index` to the beginning of the buffer.
-            for cursor in 0..(end_cursor - line_start_index) {
+            for cursor in 0..delta_bytes {
+                // The unchecked addition is safe, guaranteed by the result of the substraction
+                // above.
+                // The slice access is safe, as `line_start_index + cursor` is <= `end_cursor`,
+                // checked at the start of the function.
                 self.buffer[cursor] = self.buffer[line_start_index + cursor];
             }
 
             // Clear the rest of the buffer.
-            for cursor in (end_cursor - line_start_index)..end_cursor {
+            for cursor in delta_bytes..end_cursor {
                 self.buffer[cursor] = 0;
             }
         }
 
         // Update `read_cursor`.
-        self.read_cursor = end_cursor - line_start_index;
+        self.read_cursor = delta_bytes;
+        Ok(())
     }
 
     /// Returns the first parsed request in the queue or `None` if the queue
@@ -405,7 +483,8 @@ impl<T: Read + Write> HttpConnection<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::{Method, Version};
+    use common::{Method, Version};
+    use std::net::Shutdown;
     use std::os::unix::net::UnixStream;
 
     #[test]
@@ -795,5 +874,215 @@ mod tests {
         let mut response_buffer = vec![0u8; expected_response.len()];
         receiver.read_exact(&mut response_buffer).unwrap();
         assert_eq!(response_buffer, expected_response);
+    }
+
+    #[test]
+    fn test_try_read_negative_content_len() {
+        // Request with negative `Content-Length` header.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PUT http://localhost/home HTTP/1.1\r\n\
+                                 Content-Length: -1\r\n\r\n",
+            )
+            .unwrap();
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidHeader)
+        );
+    }
+
+    #[test]
+    fn test_read_bytes() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+
+        // Cursor positioned at buffer end. Read should fail.
+        conn.read_cursor = BUFFER_SIZE;
+        sender.write_all(b"hello\0").unwrap();
+        assert_eq!(
+            conn.read_bytes().unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Cursor positioned before buffer end. Partial read should succeed.
+        conn.read_cursor = BUFFER_SIZE - 3;
+        sender.write_all(b"hello\0").unwrap();
+        assert_eq!(conn.read_bytes(), Ok(BUFFER_SIZE));
+
+        // Read the remaining 9 bytes - 3 left from the first "hello" and the 2nd full "hello".
+        conn.read_cursor = 0;
+        assert_eq!(conn.read_bytes(), Ok(9));
+        sender.shutdown(Shutdown::Write).unwrap();
+        assert_eq!(
+            conn.read_bytes().unwrap_err(),
+            ConnectionError::ConnectionClosed
+        );
+    }
+
+    #[test]
+    fn test_shift_buffer_left() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        assert_eq!(
+            conn.shift_buffer_left(0, conn.buffer.len() + 1)
+                .unwrap_err(),
+            RequestError::Overflow
+        );
+        assert_eq!(
+            conn.shift_buffer_left(1, 0).unwrap_err(),
+            RequestError::Underflow
+        );
+        assert!(conn.shift_buffer_left(1, conn.buffer.len()).is_ok());
+    }
+
+    #[test]
+    fn test_parse_request_line() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        // Error case: end past buffer end.
+        assert_eq!(
+            conn.parse_request_line(&mut 0, conn.buffer.len() + 1)
+                .unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Error case: start is past end.
+        assert_eq!(
+            conn.parse_request_line(&mut 1, 0).unwrap_err(),
+            ConnectionError::ParseError(RequestError::Underflow)
+        );
+
+        // Error case: the request line is longer than BUFFER_SIZE.
+        assert_eq!(
+            conn.parse_request_line(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+
+        // OK case.
+        assert_eq!(conn.parse_request_line(&mut 1, BUFFER_SIZE), Ok(false));
+
+        // Error case: invalid content.
+        conn.buffer[0..8].copy_from_slice(b"foo\r\nbar");
+        assert_eq!(
+            conn.parse_request_line(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+
+        // OK case.
+        conn.buffer[0..29].copy_from_slice(b"GET http://foo/bar HTTP/1.1\r\n");
+        assert_eq!(conn.parse_request_line(&mut 0, BUFFER_SIZE), Ok(true));
+    }
+
+    #[test]
+    fn test_parse_headers() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        // Error case: end_cursor past buffer end.
+        assert_eq!(
+            conn.parse_headers(&mut 0, conn.buffer.len() + 1)
+                .unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Error case: line_start_index is past end_cursor.
+        assert_eq!(
+            conn.parse_headers(&mut 1, 0).unwrap_err(),
+            ConnectionError::ParseError(RequestError::Underflow)
+        );
+
+        // Error case: no request pending.
+        // CRLF can be at the start of the buffer...
+        conn.buffer[0] = CR;
+        conn.buffer[1] = LF;
+        assert_eq!(
+            conn.parse_headers(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeadersWithoutPendingRequest)
+        );
+        // ...or somewhere in the middle.
+        conn.buffer[0] = 0;
+        conn.buffer[1] = CR;
+        conn.buffer[2] = LF;
+        assert_eq!(
+            conn.parse_headers(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeadersWithoutPendingRequest)
+        );
+
+        // Error case: invalid header.
+        conn.pending_request = Some(Request {
+            request_line: RequestLine::new(Method::Get, "http://foo/bar", Version::Http11),
+            headers: Headers::new(0, true, true),
+            body: None,
+        });
+        assert_eq!(
+            conn.parse_headers(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidHeader)
+        );
+
+        // OK case: incomplete header line.
+        let hdr = b"Custom-Header-Testing: 1";
+        conn.buffer[..hdr.len()].copy_from_slice(hdr);
+        assert_eq!(conn.parse_headers(&mut 0, hdr.len()), Ok(false));
+
+        // OK case: complete header line.
+        let hdr = b"Custom-Header-Testing: 1\r\n";
+        conn.buffer[..hdr.len()].copy_from_slice(hdr);
+        assert_eq!(conn.parse_headers(&mut 0, hdr.len()), Ok(true));
+
+        // OK case: complete header line, end of header.
+        let hdr = b"\r\n";
+        conn.buffer[..hdr.len()].copy_from_slice(hdr);
+        assert_eq!(conn.parse_headers(&mut 0, hdr.len()), Ok(true));
+    }
+
+    #[test]
+    fn test_parse_body() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        // Error case: end_cursor past buffer end.
+        assert_eq!(
+            conn.parse_body(&mut 0usize, conn.buffer.len() + 1)
+                .unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Error case: line_start_index is past end_cursor.
+        assert_eq!(
+            conn.parse_body(&mut 1usize, 0usize).unwrap_err(),
+            ConnectionError::ParseError(RequestError::Underflow)
+        );
+
+        // OK case: consume the buffer.
+        conn.body_bytes_to_be_read = 1;
+        assert_eq!(conn.parse_body(&mut 0usize, 0usize), Ok(false));
+
+        // Error case: there's more body to be parsed, but no pending request set.
+        assert_eq!(
+            conn.parse_body(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::BodyWithoutPendingRequest)
+        );
+
+        // Error case: read more bytes than we should have into the body of the request.
+        conn.pending_request = Some(Request {
+            request_line: RequestLine::new(Method::Get, "http://foo/bar", Version::Http11),
+            headers: Headers::new(0, true, true),
+            body: None,
+        });
+        conn.body_vec = vec![0xde, 0xad, 0xbe, 0xef];
+        assert_eq!(
+            conn.parse_body(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+
+        // OK case.
+        conn.body_vec.clear();
+        assert_eq!(conn.parse_body(&mut 0, BUFFER_SIZE), Ok(true));
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -55,7 +55,7 @@ pub struct HttpConnection<T> {
 impl<T: Read + Write> HttpConnection<T> {
     /// Creates an empty connection.
     pub fn new(stream: T) -> Self {
-        HttpConnection {
+        Self {
             pending_request: None,
             stream,
             state: ConnectionState::WaitingForRequestLine,
@@ -114,8 +114,12 @@ impl<T: Read + Write> HttpConnection<T> {
         }
     }
 
-    // Reads a maximum of `BUFFER_SIZE` bytes from the stream into `buffer`.
-    // The return value represents the end index of what we have just appended.
+    /// Reads a maximum of 1024 bytes from the stream into `buffer`.
+    /// The return value represents the end index of what we have just appended.
+    ///
+    /// # Errors
+    /// `StreamError` is returned if any error occurred while reading the stream.
+    /// `ConnectionClosed` is returned if the client closed the connection.
     fn read_bytes(&mut self) -> Result<usize, ConnectionError> {
         loop {
             // Append new bytes to what we already have in the buffer.
@@ -129,8 +133,11 @@ impl<T: Read + Write> HttpConnection<T> {
         }
     }
 
-    // Parses bytes in `buffer` for a valid request line.
-    // Returns `false` if there are no more bytes to be parsed in the buffer.
+    /// Parses bytes in `buffer` for a valid request line.
+    /// Returns `false` if there are no more bytes to be parsed in the buffer.
+    ///
+    /// # Errors
+    /// `ParseError` is returned if unable to parse request line or line longer than BUFFER_SIZE.
     fn parse_request_line(
         &mut self,
         start: &mut usize,
@@ -141,13 +148,12 @@ impl<T: Read + Write> HttpConnection<T> {
                 let line = &self.buffer[*start..(*start + line_end_index)];
 
                 *start = *start + line_end_index + CRLF_LEN;
-                let request_line =
-                    RequestLine::try_from(line).map_err(ConnectionError::ParseError)?;
 
                 // Form the request with a valid request line, which is the bare minimum
                 // for a valid request.
                 self.pending_request = Some(Request {
-                    request_line,
+                    request_line: RequestLine::try_from(line)
+                        .map_err(ConnectionError::ParseError)?,
                     headers: Headers::default(),
                     body: None,
                 });
@@ -170,19 +176,23 @@ impl<T: Read + Write> HttpConnection<T> {
         }
     }
 
-    // Parses bytes in `buffer` for header fields.
-    // Returns `false` if there are no more bytes to be parsed in the buffer.
+    /// Parses bytes in `buffer` for header fields.
+    /// Returns `false` if there are no more bytes to be parsed in the buffer.
+    ///
+    /// # Errors
+    /// `ParseError` is returned if unable to parse header or line longer than BUFFER_SIZE.
     fn parse_headers(
         &mut self,
         line_start_index: &mut usize,
         end_cursor: usize,
     ) -> Result<bool, ConnectionError> {
         match find(&self.buffer[*line_start_index..end_cursor], &[CR, LF]) {
-            // We have found the end of the headers.
             // `line_start_index` points to the end of the most recently found CR LF
             // sequence. That means that if we found the next CR LF sequence at this index,
             // they are, in fact, a CR LF CR LF sequence, which marks the end of the header
             // fields, per HTTP specification.
+
+            // We have found the end of the header.
             Some(0) => {
                 // If our current state is `WaitingForHeaders`, it means that we already have
                 // a valid request formed from a request line, so it's safe to unwrap.
@@ -243,8 +253,11 @@ impl<T: Read + Write> HttpConnection<T> {
         }
     }
 
-    // Parses bytes in `buffer` to be put into the request body, if there should be one.
-    // Returns `false` if there are no more bytes to be parsed in the buffer.
+    /// Parses bytes in `buffer` to be put into the request body, if there should be one.
+    /// Returns `false` if there are no more bytes to be parsed in the buffer.
+    ///
+    /// # Errors
+    /// `ParseError` is returned when the body is larger than the specified content-length.
     fn parse_body(
         &mut self,
         line_start_index: &mut usize,
@@ -296,7 +309,10 @@ impl<T: Read + Write> HttpConnection<T> {
 
     /// Tries to write the first available response to the provided stream.
     /// Meant to be used only with non-blocking streams and an `EPOLL` structure.
-    /// Should be called whenever an `EPOLLOUT` event is signaled.
+    /// Should be called whenever an `EPOLLOUT` event is signaled. If no bytes
+    /// were written to the stream or error occurred while trying to write to stream,
+    /// we will discard all responses from response_queue because there is no way
+    /// to deliver it to client.
     ///
     /// # Errors
     /// `StreamError` is returned when an IO operation fails.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@
 //! }
 //! ```
 
+extern crate utils;
+
 mod common;
 mod connection;
 mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
 //! }
 //! ```
 
+extern crate libc;
 extern crate utils;
 
 mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 //!
 //! ## Example for parsing an HTTP Request from a slice
 //! ```
-//! extern crate micro_http;
 //! use micro_http::{Request, Version};
 //!
 //! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();
@@ -55,7 +54,6 @@
 //!
 //! ## Example for creating an HTTP Response
 //! ```
-//! extern crate micro_http;
 //! use micro_http::{Body, MediaType, Response, StatusCode, Version};
 //!
 //! let mut response = Response::new(Version::Http10, StatusCode::OK);
@@ -82,7 +80,6 @@
 //! ## Example for using the server
 //!
 //! ```
-//! extern crate micro_http;
 //! use micro_http::{HttpServer, Response, StatusCode};
 //!
 //! let path_to_socket = "/tmp/example.sock";
@@ -108,9 +105,6 @@
 //!     break;
 //! }
 //! ```
-
-extern crate libc;
-extern crate utils;
 
 mod common;
 mod connection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,10 +115,10 @@ mod server;
 use crate::common::ascii;
 use crate::common::headers;
 
+pub use self::router::{EndpointHandler, HttpRoutes, RouteError};
+pub use crate::common::headers::{Encoding, Headers, MediaType};
+pub use crate::common::{Body, HttpHeaderError, Method, Version};
 pub use crate::connection::{ConnectionError, HttpConnection};
 pub use crate::request::{Request, RequestError};
 pub use crate::response::{Response, ResponseHeaders, StatusCode};
 pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
-
-pub use crate::common::headers::{Encoding, Headers, MediaType};
-pub use crate::common::{Body, HttpHeaderError, Method, Version};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ use crate::common::headers;
 
 pub use crate::connection::{ConnectionError, HttpConnection};
 pub use crate::request::{Request, RequestError};
-pub use crate::response::{Response, StatusCode};
+pub use crate::response::{Response, ResponseHeaders, StatusCode};
 pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
 
 pub use crate::common::headers::{Encoding, Headers, MediaType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,11 +118,13 @@ mod request;
 mod response;
 mod router;
 mod server;
+use crate::common::ascii;
+use crate::common::headers;
 
-pub use self::common::headers::{Headers, MediaType};
-pub use self::common::{Body, Method, Version};
-pub use self::connection::{ConnectionError, HttpConnection};
-pub use self::request::{Request, RequestError};
-pub use self::response::{Response, StatusCode};
-pub use self::router::{EndpointHandler, HttpRoutes, RouteError};
-pub use self::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
+pub use crate::connection::{ConnectionError, HttpConnection};
+pub use crate::request::{Request, RequestError};
+pub use crate::response::{Response, StatusCode};
+pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
+
+pub use crate::common::headers::{Headers, MediaType};
+pub use crate::common::{Body, Method, Version};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,5 +120,5 @@ pub use crate::request::{Request, RequestError};
 pub use crate::response::{Response, StatusCode};
 pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
 
-pub use crate::common::headers::{Headers, MediaType};
+pub use crate::common::headers::{Encoding, Headers, MediaType};
 pub use crate::common::{Body, HttpHeaderError, Method, Version};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,4 +121,4 @@ pub use crate::response::{Response, StatusCode};
 pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
 
 pub use crate::common::headers::{Headers, MediaType};
-pub use crate::common::{Body, Method, Version};
+pub use crate::common::{Body, HttpHeaderError, Method, Version};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@
 //! ```
 //! use micro_http::{Request, Version};
 //!
-//! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();
+//! let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\r\n";
+//! let http_request = Request::try_from(request_bytes, None).unwrap();
 //! assert_eq!(http_request.http_version(), Version::Http10);
 //! assert_eq!(http_request.uri().get_abs_path(), "/home");
 //! ```

--- a/src/request.rs
+++ b/src/request.rs
@@ -129,15 +129,6 @@ impl RequestLine {
     fn min_len() -> usize {
         Method::Get.raw().len() + 1 + Version::Http10.raw().len() + 2
     }
-
-    #[cfg(test)]
-    pub fn new(method: Method, uri: &str, http_version: Version) -> Self {
-        Self {
-            method,
-            uri: Uri::new(uri),
-            http_version,
-        }
-    }
 }
 
 /// Wrapper over an HTTP Request.
@@ -271,6 +262,16 @@ mod tests {
                 && self.headers.content_length() == other.headers.content_length()
                 && self.headers.expect() == other.headers.expect()
                 && self.headers.chunked() == other.headers.chunked()
+        }
+    }
+
+    impl RequestLine {
+        pub fn new(method: Method, uri: &str, http_version: Version) -> Self {
+            Self {
+                method,
+                uri: Uri::new(uri),
+                http_version,
+            }
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,10 +4,9 @@
 use std::str::from_utf8;
 
 use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
-use crate::common::headers::Headers;
-use crate::common::{Body, Method, Version};
-
 pub use crate::common::RequestError;
+use crate::common::{Body, Method, Version};
+use crate::headers::Headers;
 
 // This type represents the RequestLine raw parts: method, uri and version.
 type RequestLineParts<'a> = (&'a [u8], &'a [u8], &'a [u8]);

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,7 +9,10 @@ use crate::common::{Body, Method, Version};
 
 pub use crate::common::RequestError;
 
-/// Finds the first occurrence of `sequence` in the `bytes` slice.
+// This type represents the RequestLine raw parts: method, uri and version.
+type RequestLineParts<'a> = (&'a [u8], &'a [u8], &'a [u8]);
+
+/// Finds the first occurence of `sequence` in the `bytes` slice.
 ///
 /// Returns the starting position of the `sequence` in `bytes` or `None` if the
 /// `sequence` is not found.
@@ -58,6 +61,7 @@ impl Uri {
         const HTTP_SCHEME_PREFIX: &str = "http://";
 
         if self.string.starts_with(HTTP_SCHEME_PREFIX) {
+            // Slice access is safe because we checked above that `self.string` size <= `HTTP_SCHEME_PREFIX.len()`.
             let without_scheme = &self.string[HTTP_SCHEME_PREFIX.len()..];
             if without_scheme.is_empty() {
                 return "";
@@ -65,6 +69,7 @@ impl Uri {
             // The host in this case includes the port and contains the bytes after http:// up to
             // the next '/'.
             match without_scheme.bytes().position(|byte| byte == b'/') {
+                // Slice access is safe because `position` validates that `len` is a valid index.
                 Some(len) => &without_scheme[len..],
                 None => "",
             }
@@ -87,24 +92,36 @@ pub struct RequestLine {
 }
 
 impl RequestLine {
-    fn parse_request_line(request_line: &[u8]) -> (&[u8], &[u8], &[u8]) {
+    fn parse_request_line(
+        request_line: &[u8],
+    ) -> std::result::Result<RequestLineParts, RequestError> {
         if let Some(method_end) = find(request_line, &[SP]) {
+            // The slice access is safe because `find` validates that `method_end` < `request_line` size.
             let method = &request_line[..method_end];
 
-            let uri_and_version = &request_line[(method_end + 1)..];
+            // `uri_start` <= `request_line` size.
+            let uri_start = method_end.checked_add(1).ok_or(RequestError::Overflow)?;
+
+            // Slice access is safe because `uri_start` <= `request_line` size.
+            // If `uri_start` == `request_line` size, then `uri_and_version` will be an empty slice.
+            let uri_and_version = &request_line[uri_start..];
 
             if let Some(uri_end) = find(uri_and_version, &[SP]) {
+                // Slice access is safe because `find` validates that `uri_end` < `uri_and_version` size.
                 let uri = &uri_and_version[..uri_end];
 
-                let version = &uri_and_version[(uri_end + 1)..];
+                // `version_start` <= `uri_and_version` size.
+                let version_start = uri_end.checked_add(1).ok_or(RequestError::Overflow)?;
 
-                return (method, uri, version);
+                // Slice access is safe because `version_start` <= `uri_and_version` size.
+                let version = &uri_and_version[version_start..];
+
+                return Ok((method, uri, version));
             }
-
-            return (method, uri_and_version, b"");
         }
 
-        (b"", b"", b"")
+        // Request Line can be valid only if it contains the method, uri and version separated with SP.
+        Err(RequestError::InvalidRequest)
     }
 
     /// Tries to parse a byte stream in a request line. Fails if the request line is malformed.
@@ -114,7 +131,7 @@ impl RequestLine {
     /// `InvalidHttpVersion` is returned if the specified HTTP version is unsupported.
     /// `InvalidUri` is returned if the specified Uri is not valid.
     pub fn try_from(request_line: &[u8]) -> Result<Self, RequestError> {
-        let (method, uri, version) = Self::parse_request_line(request_line);
+        let (method, uri, version) = Self::parse_request_line(request_line)?;
 
         Ok(Self {
             method: Method::try_from(method)?,
@@ -124,9 +141,10 @@ impl RequestLine {
     }
 
     // Returns the minimum length of a valid request. The request must contain
-    // the method (GET), the URI (minmum 1 character), the HTTP version(HTTP/DIGIT.DIGIT) and
+    // the method (GET), the URI (minimum 1 character), the HTTP version(HTTP/DIGIT.DIGIT) and
     // 2 separators (SP).
     fn min_len() -> usize {
+        // Addition is safe because these are small constants.
         Method::Get.raw().len() + 1 + Version::Http10.raw().len() + 2
     }
 }
@@ -148,7 +166,10 @@ impl Request {
     /// The byte slice is expected to have the following format: </br>
     ///     * Request Line: "GET SP Request-uri SP HTTP/1.0 CRLF" - Mandatory </br>
     ///     * Request Headers "<headers> CRLF"- Optional </br>
+    ///     * Empty Line "CRLF" </br>
     ///     * Entity Body - Optional </br>
+    /// The request headers and the entity body are not parsed and None is returned because
+    /// these are not used by the MMDS server.
     /// The only supported method is GET and the HTTP protocol is expected to be HTTP/1.0
     /// or HTTP/1.1.
     ///
@@ -171,6 +192,7 @@ impl Request {
             None => return Err(RequestError::InvalidRequest),
         };
 
+        // Slice access is safe because `find` validates that `request_line_end` < `byte_stream` size.
         let request_line_bytes = &byte_stream[..request_line_end];
         if request_line_bytes.len() < RequestLine::min_len() {
             return Err(RequestError::InvalidRequest);
@@ -191,8 +213,20 @@ impl Request {
             Some(headers_end) => {
                 // Parse the request headers.
                 // Start by removing the leading CR LF from them.
-                let headers_and_body = &byte_stream[(request_line_end + CRLF_LEN)..];
+                let headers_start = request_line_end
+                    .checked_add(CRLF_LEN)
+                    .ok_or(RequestError::Overflow)?;
+                // Slice access is safe because starting from `request_line_end` there are at least two CRLF
+                // (enforced by `find` at the start of this method).
+                let headers_and_body = &byte_stream[headers_start..];
+                // Because we advanced the start with CRLF_LEN, we now have to subtract CRLF_LEN
+                // from the end in order to keep the same window.
+                // Underflow is not possible here because `byte_stream[request_line_end..]` starts with CR LF,
+                // so `headers_end` can be either zero (this case is treated separately in the first match arm)
+                // or >= 3 (current case).
                 let headers_end = headers_end - CRLF_LEN;
+                // Slice access is safe because `headers_end` is checked above
+                // (`find` gives a valid position, and  subtracting 2 can't underflow).
                 let headers = Headers::try_from(&headers_and_body[..headers_end])?;
 
                 // Parse the body of the request.
@@ -203,16 +237,22 @@ impl Request {
                         None
                     }
                     content_length => {
+                        // Multiplication is safe because `CRLF_LEN` is a small constant.
+                        let crlf_end = headers_end
+                            .checked_add(2 * CRLF_LEN)
+                            .ok_or(RequestError::Overflow)?;
+                        // This can't underflow because `headers_and_body.len()` >= `crlf_end`.
+                        let body_len = headers_and_body.len() - crlf_end;
                         // Headers suggest we have a body, but the buffer is shorter than the specified
                         // content length.
-                        if headers_and_body.len() - (headers_end + 2 * CRLF_LEN)
-                            < content_length as usize
-                        {
+                        if body_len < content_length as usize {
                             return Err(RequestError::InvalidRequest);
                         }
-                        let body_as_bytes = &headers_and_body[(headers_end + 2 * CRLF_LEN)..];
+                        // Slice access is safe because `crlf_end` is the index after two CRLF
+                        // (it is <= `headers_and_body` size).
+                        let body_as_bytes = &headers_and_body[crlf_end..];
                         // If the actual length of the body is different than the `Content-Length` value
-                        // in the headers then this request is invalid.
+                        // in the headers, then this request is invalid.
                         if body_as_bytes.len() == content_length as usize {
                             Some(Body::new(body_as_bytes))
                         } else {
@@ -341,6 +381,13 @@ mod tests {
             expected_request_line
         );
 
+        // Test for invalid request missing the separator.
+        let request_line = b"GET";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
         // Test for invalid method.
         let request_line = b"CONNECT http://localhost/home HTTP/1.0";
         assert_eq!(
@@ -366,14 +413,14 @@ mod tests {
         let request_line = b"nothing";
         assert_eq!(
             RequestLine::try_from(request_line).unwrap_err(),
-            RequestError::InvalidHttpMethod("Unsupported HTTP method.")
+            RequestError::InvalidRequest
         );
 
         // Test for invalid format with no version.
         let request_line = b"GET /";
         assert_eq!(
             RequestLine::try_from(request_line).unwrap_err(),
-            RequestError::InvalidHttpVersion("Unsupported HTTP version.")
+            RequestError::InvalidRequest
         );
     }
 
@@ -395,6 +442,13 @@ mod tests {
         assert_eq!(request.uri(), &Uri::new("http://localhost/home"));
         assert_eq!(request.http_version(), Version::Http10);
         assert!(request.body.is_none());
+
+        // Test for invalid Request (missing CR LF).
+        let request_bytes = b"GET / HTTP/1.1";
+        assert_eq!(
+            Request::try_from(request_bytes).unwrap_err(),
+            RequestError::InvalidRequest
+        );
 
         // Test for invalid Request (length is less than minimum).
         let request_bytes = b"GET";
@@ -440,7 +494,6 @@ mod tests {
         // Test for an invalid content length.
         let request = Request::try_from(
             b"PATCH http://localhost/home HTTP/1.1\r\n\
-                                     Expect: 100-continue\r\n\
                                      Content-Length: 5000\r\n\r\nthis is a short body",
         )
         .unwrap_err();

--- a/src/request.rs
+++ b/src/request.rs
@@ -276,45 +276,34 @@ mod tests {
 
     #[test]
     fn test_uri() {
-        let uri = Uri::new("http://localhost/home");
-        assert_eq!(uri.get_abs_path(), "/home");
-
-        let uri = Uri::new("/home");
-        assert_eq!(uri.get_abs_path(), "/home");
-
-        let uri = Uri::new("home");
-        assert_eq!(uri.get_abs_path(), "");
-
-        let uri = Uri::new("http://");
-        assert_eq!(uri.get_abs_path(), "");
-
-        let uri = Uri::new("http://192.168.0.0");
-        assert_eq!(uri.get_abs_path(), "");
+        for tc in &vec![
+            ("http://localhost/home", "/home"),
+            ("http://localhost:8080/home", "/home"),
+            ("http://localhost/home/sub", "/home/sub"),
+            ("/home", "/home"),
+            ("home", ""),
+            ("http://", ""),
+            ("http://192.168.0.0", ""),
+        ] {
+            assert_eq!(Uri::new(tc.0).get_abs_path(), tc.1);
+        }
     }
 
     #[test]
     fn test_find() {
         let bytes: &[u8; 13] = b"abcacrgbabsjl";
-        let i = find(&bytes[..], b"ac");
-        assert_eq!(i.unwrap(), 3);
 
-        let i = find(&bytes[..], b"rgb");
-        assert_eq!(i.unwrap(), 5);
-
-        let i = find(&bytes[..], b"ab");
-        assert_eq!(i.unwrap(), 0);
-
-        let i = find(&bytes[..], b"l");
-        assert_eq!(i.unwrap(), 12);
-
-        let i = find(&bytes[..], b"jle");
-        assert!(i.is_none());
-
-        let i = find(&bytes[..], b"asdkjhasjhdjhgsadg");
-        assert!(i.is_none());
-
-        let i = find(&bytes[..], b"abcacrgbabsjl");
-        assert_eq!(i.unwrap(), 0);
+        for tc in &vec![
+            ("ac", Some(3)),
+            ("rgb", Some(5)),
+            ("ab", Some(0)),
+            ("l", Some(12)),
+            ("abcacrgbabsjl", Some(0)),
+            ("jle", None),
+            ("asdkjhasjhdjhgsadg", None),
+        ] {
+            assert_eq!(find(&bytes[..], tc.0.as_bytes()), tc.1);
+        }
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,7 +12,7 @@ use crate::headers::Headers;
 // This type represents the RequestLine raw parts: method, uri and version.
 type RequestLineParts<'a> = (&'a [u8], &'a [u8], &'a [u8]);
 
-/// Finds the first occurence of `sequence` in the `bytes` slice.
+/// Finds the first occurrence of `sequence` in the `bytes` slice.
 ///
 /// Returns the starting position of the `sequence` in `bytes` or `None` if the
 /// `sequence` is not found.

--- a/src/request.rs
+++ b/src/request.rs
@@ -178,7 +178,6 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::Request;
     ///
     /// let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs::File;
 use std::str::from_utf8;
 
 use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
@@ -158,6 +159,8 @@ pub struct Request {
     pub headers: Headers,
     /// The body of the request.
     pub body: Option<Body>,
+    /// The optional file associated with the request.
+    pub file: Option<File>,
 }
 
 impl Request {
@@ -217,6 +220,7 @@ impl Request {
                 request_line,
                 headers: Headers::default(),
                 body: None,
+                file: None,
             }),
             Some(headers_end) => {
                 // Parse the request headers.
@@ -276,6 +280,7 @@ impl Request {
                     request_line,
                     headers,
                     body,
+                    file: None,
                 })
             }
             // If we can't find a CR LF CR LF even though the request should have headers
@@ -444,6 +449,7 @@ mod tests {
                 uri: Uri::new("http://localhost/home"),
             },
             body: None,
+            file: None,
             headers: Headers::default(),
         };
         let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,6 +4,7 @@
 use std::str::from_utf8;
 
 use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
+pub use crate::common::HttpHeaderError;
 pub use crate::common::RequestError;
 use crate::common::{Body, Method, Version};
 use crate::headers::Headers;
@@ -480,14 +481,13 @@ mod tests {
         Request::try_from(b"PATCH http://localhost/home HTTP/1.1\r\n").unwrap_err();
 
         // Test for an invalid encoding.
-        let request = Request::try_from(
+        assert!(Request::try_from(
             b"PATCH http://localhost/home HTTP/1.1\r\n\
                                      Expect: 100-continue\r\n\
                                      Transfer-Encoding: identity; q=0\r\n\
                                      Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
         )
-        .unwrap_err();
-        assert_eq!(request, RequestError::InvalidHeader);
+        .is_ok());
 
         // Test for an invalid content length.
         let request = Request::try_from(

--- a/src/request.rs
+++ b/src/request.rs
@@ -510,5 +510,15 @@ mod tests {
         assert_eq!(request.headers.expect(), false);
         assert_eq!(request.headers.content_length(), 0);
         assert!(request.body.is_none());
+
+        let request = Request::try_from(b"GET http://localhost/ HTTP/1.0\r\n\
+                                                                              Accept-Encoding: identity;q=0\r\n\r\n");
+        assert_eq!(
+            request.unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                "identity;q=0".to_string()
+            ))
+        );
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,6 +22,8 @@ pub enum StatusCode {
     NoContent,
     /// 400, Bad Request
     BadRequest,
+    /// 401, Unauthorized
+    Unauthorized,
     /// 404, Not Found
     NotFound,
     /// 405, Method Not Allowed
@@ -42,6 +44,7 @@ impl StatusCode {
             Self::OK => b"200",
             Self::NoContent => b"204",
             Self::BadRequest => b"400",
+            Self::Unauthorized => b"401",
             Self::NotFound => b"404",
             Self::MethodNotAllowed => b"405",
             Self::InternalServerError => b"500",
@@ -369,6 +372,7 @@ mod tests {
         assert_eq!(StatusCode::OK.raw(), b"200");
         assert_eq!(StatusCode::NoContent.raw(), b"204");
         assert_eq!(StatusCode::BadRequest.raw(), b"400");
+        assert_eq!(StatusCode::Unauthorized.raw(), b"401");
         assert_eq!(StatusCode::NotFound.raw(), b"404");
         assert_eq!(StatusCode::MethodNotAllowed.raw(), b"405");
         assert_eq!(StatusCode::InternalServerError.raw(), b"500");

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,10 +3,10 @@
 
 use std::io::{Error as WriteError, Write};
 
-use ascii::{COLON, CR, LF, SP};
-use common::{Body, Version};
-use headers::{Header, MediaType};
-use Method;
+use crate::ascii::{COLON, CR, LF, SP};
+use crate::common::{Body, Version};
+use crate::headers::{Header, MediaType};
+use crate::Method;
 
 /// Wrapper over a response status code.
 ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,9 +3,10 @@
 
 use std::io::{Error as WriteError, Write};
 
-use crate::common::ascii::{COLON, CR, LF, SP};
-use crate::common::headers::{Header, MediaType};
-use crate::common::{Body, Version};
+use ascii::{COLON, CR, LF, SP};
+use common::{Body, Version};
+use headers::{Header, MediaType};
+use Method;
 
 /// Wrapper over a response status code.
 ///
@@ -23,6 +24,8 @@ pub enum StatusCode {
     BadRequest,
     /// 404, Not Found
     NotFound,
+    /// 405, Method Not Allowed
+    MethodNotAllowed,
     /// 500, Internal Server Error
     InternalServerError,
     /// 501, Not Implemented
@@ -40,6 +43,7 @@ impl StatusCode {
             Self::NoContent => b"204",
             Self::BadRequest => b"400",
             Self::NotFound => b"404",
+            Self::MethodNotAllowed => b"405",
             Self::InternalServerError => b"500",
             Self::NotImplemented => b"501",
             Self::ServiceUnavailable => b"503",
@@ -77,6 +81,7 @@ pub struct ResponseHeaders {
     content_length: i32,
     content_type: MediaType,
     server: String,
+    allow: Vec<Method>,
 }
 
 impl Default for ResponseHeaders {
@@ -85,11 +90,31 @@ impl Default for ResponseHeaders {
             content_length: Default::default(),
             content_type: Default::default(),
             server: String::from("Firecracker API"),
+            allow: Vec::new(),
         }
     }
 }
 
 impl ResponseHeaders {
+    // The logic pertaining to `Allow` header writing.
+    fn write_allow_header<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
+        if self.allow.is_empty() {
+            return Ok(());
+        }
+
+        buf.write_all(b"Allow: ")?;
+
+        let delimitator = b", ";
+        for (idx, method) in self.allow.iter().enumerate() {
+            buf.write_all(method.raw())?;
+            if idx < self.allow.len() - 1 {
+                buf.write_all(delimitator)?;
+            }
+        }
+
+        buf.write_all(&[CR, LF])
+    }
+
     /// Writes the headers to `buf` using the HTTP specification.
     pub fn write_all<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
         buf.write_all(Header::Server.raw())?;
@@ -99,6 +124,8 @@ impl ResponseHeaders {
 
         buf.write_all(b"Connection: keep-alive")?;
         buf.write_all(&[CR, LF])?;
+
+        self.write_allow_header(buf)?;
 
         if self.content_length != 0 {
             buf.write_all(Header::ContentType.raw())?;
@@ -172,6 +199,16 @@ impl Response {
         self.headers.set_server(server);
     }
 
+    /// Sets the HTTP allowed methods.
+    pub fn set_allow(&mut self, methods: Vec<Method>) {
+        self.headers.allow = methods;
+    }
+
+    /// Allows a specific HTTP method.
+    pub fn allow_method(&mut self, method: Method) {
+        self.headers.allow.push(method);
+    }
+
     fn write_body<T: Write>(&self, mut buf: T) -> Result<(), WriteError> {
         if let Some(ref body) = self.body {
             buf.write_all(body.raw())?;
@@ -216,6 +253,11 @@ impl Response {
     pub fn http_version(&self) -> Version {
         self.status_line.http_version
     }
+
+    /// Returns the allowed HTTP methods.
+    pub fn allow(&self) -> Vec<Method> {
+        self.headers.allow.clone()
+    }
 }
 
 #[cfg(test)]
@@ -245,6 +287,20 @@ mod tests {
         let mut response_buf: [u8; 126] = [0; 126];
         assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
         assert!(response_buf.as_ref() == expected_response);
+
+        // Test response `Allow` header.
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
+        let allowed_methods = vec![Method::Get, Method::Patch, Method::Put];
+        response.set_allow(allowed_methods.clone());
+        assert_eq!(response.allow(), allowed_methods);
+
+        let expected_response: &'static [u8] = b"HTTP/1.0 200 \r\n\
+            Server: Firecracker API\r\n\
+            Connection: keep-alive\r\n\
+            Allow: GET, PATCH, PUT\r\n\r\n";
+        let mut response_buf: [u8; 90] = [0; 90];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert_eq!(response_buf.as_ref(), expected_response);
 
         // Test write failed.
         let mut response_buf: [u8; 1] = [0; 1];
@@ -288,8 +344,17 @@ mod tests {
         assert_eq!(StatusCode::NoContent.raw(), b"204");
         assert_eq!(StatusCode::BadRequest.raw(), b"400");
         assert_eq!(StatusCode::NotFound.raw(), b"404");
+        assert_eq!(StatusCode::MethodNotAllowed.raw(), b"405");
         assert_eq!(StatusCode::InternalServerError.raw(), b"500");
         assert_eq!(StatusCode::NotImplemented.raw(), b"501");
         assert_eq!(StatusCode::ServiceUnavailable.raw(), b"503");
+    }
+
+    #[test]
+    fn test_allow_method() {
+        let mut response = Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+        response.allow_method(Method::Get);
+        response.allow_method(Method::Put);
+        assert_eq!(response.allow(), vec![Method::Get, Method::Put]);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -263,12 +263,12 @@ impl Response {
         self.body.clone()
     }
 
-    /// Returns the HTTP Version of the response.
+    /// Returns the Content Length of the response.
     pub fn content_length(&self) -> i32 {
         self.headers.content_length
     }
 
-    /// Returns the HTTP Version of the response.
+    /// Returns the Content Type of the response.
     pub fn content_type(&self) -> MediaType {
         self.headers.content_type
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -383,4 +383,15 @@ mod tests {
         response.allow_method(Method::Put);
         assert_eq!(response.allow(), vec![Method::Get, Method::Put]);
     }
+
+    #[test]
+    fn test_equal() {
+        let response = Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+        let another_response = Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+        assert_eq!(response, another_response);
+
+        let response = Response::new(Version::Http10, StatusCode::OK);
+        let another_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        assert_ne!(response, another_response);
+    }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -35,14 +35,14 @@ impl StatusCode {
     /// Returns the status code as bytes.
     pub fn raw(self) -> &'static [u8; 3] {
         match self {
-            StatusCode::Continue => b"100",
-            StatusCode::OK => b"200",
-            StatusCode::NoContent => b"204",
-            StatusCode::BadRequest => b"400",
-            StatusCode::NotFound => b"404",
-            StatusCode::InternalServerError => b"500",
-            StatusCode::NotImplemented => b"501",
-            StatusCode::ServiceUnavailable => b"503",
+            Self::Continue => b"100",
+            Self::OK => b"200",
+            Self::NoContent => b"204",
+            Self::BadRequest => b"400",
+            Self::NotFound => b"404",
+            Self::InternalServerError => b"500",
+            Self::NotImplemented => b"501",
+            Self::ServiceUnavailable => b"503",
         }
     }
 }
@@ -54,7 +54,7 @@ struct StatusLine {
 
 impl StatusLine {
     fn new(http_version: Version, status_code: StatusCode) -> Self {
-        StatusLine {
+        Self {
             http_version,
             status_code,
         }
@@ -81,10 +81,10 @@ pub struct ResponseHeaders {
 
 impl Default for ResponseHeaders {
     fn default() -> Self {
-        ResponseHeaders {
+        Self {
             content_length: Default::default(),
             content_type: Default::default(),
-            server: "Firecracker API".to_string(),
+            server: String::from("Firecracker API"),
         }
     }
 }
@@ -134,7 +134,9 @@ impl ResponseHeaders {
 /// Wrapper over an HTTP Response.
 ///
 /// The Response is created using a `Version` and a `StatusCode`. When creating a Response object,
-/// the body is initialized to `None`. The body can be updated with a call to `set_body`.
+/// the body is initialized to `None` and the header is initialized with the `default` value. The body
+/// can be updated with a call to `set_body`. The header can be updated with `set_content_type` and
+/// `set_server`.
 pub struct Response {
     status_line: StatusLine,
     headers: ResponseHeaders,
@@ -143,11 +145,11 @@ pub struct Response {
 
 impl Response {
     /// Creates a new HTTP `Response` with an empty body.
-    pub fn new(http_version: Version, status_code: StatusCode) -> Response {
-        Response {
+    pub fn new(http_version: Version, status_code: StatusCode) -> Self {
+        Self {
             status_line: StatusLine::new(http_version, status_code),
             headers: ResponseHeaders::default(),
-            body: None,
+            body: Default::default(),
         }
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -109,6 +109,7 @@ impl ResponseHeaders {
         let delimitator = b", ";
         for (idx, method) in self.allow.iter().enumerate() {
             buf.write_all(method.raw())?;
+            // We check above that `self.allow` is not empty.
             if idx < self.allow.len() - 1 {
                 buf.write_all(delimitator)?;
             }

--- a/src/response.rs
+++ b/src/response.rs
@@ -51,6 +51,7 @@ impl StatusCode {
     }
 }
 
+#[derive(Debug, PartialEq)]
 struct StatusLine {
     http_version: Version,
     status_code: StatusCode,
@@ -77,6 +78,7 @@ impl StatusLine {
 /// Wrapper over the list of headers associated with a HTTP Response.
 /// When creating a ResponseHeaders object, the content type is initialized to `text/plain`.
 /// The content type can be updated with a call to `set_content_type`.
+#[derive(Debug, PartialEq)]
 pub struct ResponseHeaders {
     content_length: i32,
     content_type: MediaType,
@@ -164,6 +166,7 @@ impl ResponseHeaders {
 /// the body is initialized to `None` and the header is initialized with the `default` value. The body
 /// can be updated with a call to `set_body`. The header can be updated with `set_content_type` and
 /// `set_server`.
+#[derive(Debug, PartialEq)]
 pub struct Response {
     status_line: StatusLine,
     headers: ResponseHeaders,

--- a/src/response.rs
+++ b/src/response.rs
@@ -84,6 +84,7 @@ pub struct ResponseHeaders {
     content_type: MediaType,
     server: String,
     allow: Vec<Method>,
+    accept_encoding: bool,
 }
 
 impl Default for ResponseHeaders {
@@ -93,6 +94,7 @@ impl Default for ResponseHeaders {
             content_type: Default::default(),
             server: String::from("Firecracker API"),
             allow: Vec::new(),
+            accept_encoding: false,
         }
     }
 }
@@ -140,6 +142,13 @@ impl ResponseHeaders {
             buf.write_all(&[COLON, SP])?;
             buf.write_all(self.content_length.to_string().as_bytes())?;
             buf.write_all(&[CR, LF])?;
+
+            if self.accept_encoding {
+                buf.write_all(Header::AcceptEncoding.raw())?;
+                buf.write_all(&[COLON, SP])?;
+                buf.write_all(b"identity")?;
+                buf.write_all(&[CR, LF])?;
+            }
         }
 
         buf.write_all(&[CR, LF])
@@ -158,6 +167,12 @@ impl ResponseHeaders {
     /// Sets the content type to be written in the HTTP response.
     pub fn set_content_type(&mut self, content_type: MediaType) {
         self.content_type = content_type;
+    }
+
+    /// Sets the encoding type to be written in the HTTP response.
+    #[allow(unused)]
+    pub fn set_encoding(&mut self) {
+        self.accept_encoding = true;
     }
 }
 
@@ -196,6 +211,11 @@ impl Response {
     /// Updates the content type of the `Response`.
     pub fn set_content_type(&mut self, content_type: MediaType) {
         self.headers.set_content_type(content_type);
+    }
+
+    /// Updates the encoding type of `Response`.
+    pub fn set_encoding(&mut self) {
+        self.headers.set_encoding();
     }
 
     /// Sets the HTTP response server.
@@ -274,8 +294,9 @@ mod tests {
         let body = "This is a test";
         response.set_body(Body::new(body));
         response.set_content_type(MediaType::PlainText);
+        response.set_encoding();
 
-        assert!(response.status() == StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.body().unwrap(), Body::new(body));
         assert_eq!(response.http_version(), Version::Http10);
         assert_eq!(response.content_length(), 14);
@@ -285,12 +306,13 @@ mod tests {
             Server: Firecracker API\r\n\
             Connection: keep-alive\r\n\
             Content-Type: text/plain\r\n\
-            Content-Length: 14\r\n\r\n\
+            Content-Length: 14\r\n\
+            Accept-Encoding: identity\r\n\r\n\
             This is a test";
 
-        let mut response_buf: [u8; 126] = [0; 126];
+        let mut response_buf: [u8; 153] = [0; 153];
         assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
-        assert!(response_buf.as_ref() == expected_response);
+        assert_eq!(response_buf.as_ref(), expected_response);
 
         // Test response `Allow` header.
         let mut response = Response::new(Version::Http10, StatusCode::OK);
@@ -320,7 +342,7 @@ mod tests {
         response.set_content_type(MediaType::PlainText);
         response.set_server(server);
 
-        assert!(response.status() == StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.body().unwrap(), Body::new(body));
         assert_eq!(response.http_version(), Version::Http10);
         assert_eq!(response.content_length(), 14);

--- a/src/router.rs
+++ b/src/router.rs
@@ -79,8 +79,8 @@ impl<T: Send> HttpRoutes<T> {
     /// let handler = MockHandler {};
     /// router.add_route(Method::Get, "/func1".to_string(), Box::new(handler)).unwrap();
     ///
-    /// let request =
-    ///     Request::try_from(b"GET http://localhost/api/v1/func1 HTTP/1.1\r\n\r\n").unwrap();
+    /// let request_bytes = b"GET http://localhost/api/v1/func1 HTTP/1.1\r\n\r\n";
+    /// let request = Request::try_from(request_bytes, None).unwrap();
     /// let arg = HandlerArg(true);
     /// let reply = router.handle_http_request(&request, &arg);
     /// assert_eq!(reply.status(), StatusCode::OK);
@@ -148,7 +148,7 @@ mod tests {
             .unwrap();
 
         let request =
-            Request::try_from(b"GET http://localhost/api/v1/func2 HTTP/1.1\r\n\r\n").unwrap();
+            Request::try_from(b"GET http://localhost/api/v1/func2 HTTP/1.1\r\n\r\n", None).unwrap();
         let arg = HandlerArg(true);
         let reply = router.handle_http_request(&request, &arg);
         assert_eq!(reply.status(), StatusCode::NotFound);

--- a/src/server.rs
+++ b/src/server.rs
@@ -765,7 +765,8 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Type: application/json\r\n\r\n"
+            Content-Type: application/json\r\n\r\n",
+                None
             )
             .unwrap()
         );
@@ -989,7 +990,8 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Type: application/json\r\n\r\n"
+            Content-Type: application/json\r\n\r\n",
+                None
             )
             .unwrap()
         );

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use logger::error;
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
@@ -49,9 +49,9 @@ impl ServerRequest {
     /// The response is then wrapped in a `ServerResponse`.
     ///
     /// Returns a `ServerResponse` ready for yielding to the server
-    pub fn process<F>(&self, callable: F) -> ServerResponse
+    pub fn process<F>(&self, mut callable: F) -> ServerResponse
     where
-        F: Fn(&Request) -> Response,
+        F: FnMut(&Request) -> Response,
     {
         let http_response = callable(self.inner());
         ServerResponse::new(http_response, self.id)
@@ -386,6 +386,27 @@ impl HttpServer {
         });
 
         Ok(parsed_requests)
+    }
+
+    /// This function is responsible with flushing any remaining outgoing
+    /// requests on the server.
+    ///
+    /// Note that this function can block the thread on write, since the
+    /// operation is blocking.
+    pub fn flush_outgoing_writes(&mut self) {
+        for (_, connection) in self.connections.iter_mut() {
+            while connection.state == ClientConnectionState::AwaitingOutgoing {
+                if let Err(e) = connection.write() {
+                    if let ServerError::ConnectionError(ConnectionError::InvalidWrite) = e {
+                        // Nothing is logged since an InvalidWrite means we have successfully
+                        // flushed the connection
+                    } else {
+                        error!("Connection write error: {}", e);
+                    }
+                    break;
+                }
+            }
+        }
     }
 
     /// The file descriptor of the `epoll` structure can enable the server to become

--- a/src/server.rs
+++ b/src/server.rs
@@ -554,7 +554,7 @@ mod tests {
     use common::Body;
     use utils::tempfile::TempFile;
 
-    fn get_path_to_socket() -> TempFile {
+    fn get_temp_socket_file() -> TempFile {
         let mut path_to_socket = TempFile::new().unwrap();
         path_to_socket.remove().unwrap();
         path_to_socket
@@ -562,7 +562,7 @@ mod tests {
 
     #[test]
     fn test_wait_one_connection() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn test_wait_concurrent_connections() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn test_wait_expect_connection() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_wait_many_connections() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -739,7 +739,7 @@ mod tests {
 
     #[test]
     fn test_wait_parse_error() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -772,7 +772,7 @@ mod tests {
 
     #[test]
     fn test_wait_in_flight_responses() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -148,7 +148,10 @@ impl<T: Read + Write> ClientConnection<T> {
                 }
             }
         }
-        self.in_flight_response_count += parsed_requests.len() as u32;
+        self.in_flight_response_count = self
+            .in_flight_response_count
+            .checked_add(parsed_requests.len() as u32)
+            .ok_or(ServerError::Overflow)?;
         // If the state of the connection has changed, we need to update
         // the event set in the `epoll` structure.
         if self.connection.pending_write() {
@@ -180,11 +183,15 @@ impl<T: Read + Write> ClientConnection<T> {
         Ok(())
     }
 
-    fn enqueue_response(&mut self, response: Response) {
+    fn enqueue_response(&mut self, response: Response) -> Result<()> {
         if self.state != ClientConnectionState::Closed {
             self.connection.enqueue_response(response);
         }
-        self.in_flight_response_count -= 1;
+        self.in_flight_response_count = self
+            .in_flight_response_count
+            .checked_sub(1)
+            .ok_or(ServerError::Underflow)?;
+        Ok(())
     }
 
     // Returns `true` if the connection is closed and safe to drop.
@@ -460,6 +467,7 @@ impl HttpServer {
     ///
     /// # Errors
     /// `IOError` is returned when an `epoll::ctl` operation fails.
+    /// `Underflow` is returned when `enqueue_response` fails.
     pub fn respond(&mut self, response: ServerResponse) -> Result<()> {
         if let Some(client_connection) = self.connections.get_mut(&(response.id as i32)) {
             // If the connection was incoming before we enqueue the response, we change its
@@ -468,7 +476,7 @@ impl HttpServer {
                 client_connection.state = ClientConnectionState::AwaitingOutgoing;
                 Self::epoll_mod(&self.epoll, response.id as RawFd, epoll::EventSet::OUT)?;
             }
-            client_connection.enqueue_response(response.response);
+            client_connection.enqueue_response(response.response)?;
         }
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -754,8 +754,7 @@ mod tests {
         second_socket
             .write_all(
                 b"GET /machine-config HTTP/1.1\r\n\
-                                Content-Length: 20\r\n\
-                                Content-Type: application/json\r\n\r\nwhatever second body",
+                                Content-Type: application/json\r\n\r\n",
             )
             .unwrap();
 
@@ -766,8 +765,7 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Length: 20\r\n\
-            Content-Type: application/json\r\n\r\nwhatever second body"
+            Content-Type: application/json\r\n\r\n"
             )
             .unwrap()
         );
@@ -980,8 +978,7 @@ mod tests {
         second_socket
             .write_all(
                 b"GET /machine-config HTTP/1.1\r\n\
-                                Content-Length: 20\r\n\
-                                Content-Type: application/json\r\n\r\nwhatever second body",
+                                Content-Type: application/json\r\n\r\n",
             )
             .unwrap();
 
@@ -992,8 +989,7 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Length: 20\r\n\
-            Content-Type: application/json\r\n\r\nwhatever second body"
+            Content-Type: application/json\r\n\r\n"
             )
             .unwrap()
         );

--- a/src/server.rs
+++ b/src/server.rs
@@ -193,6 +193,11 @@ impl<T: Read + Write> ClientConnection<T> {
         Ok(())
     }
 
+    /// Discards all pending writes from the inner connection.
+    fn clear_write_buffer(&mut self) {
+        self.connection.clear_write_buffer();
+    }
+
     // Returns `true` if the connection is closed and safe to drop.
     fn is_done(&self) -> bool {
         self.state == ClientConnectionState::Closed
@@ -343,6 +348,22 @@ impl HttpServer {
                 // We have a notification on one of our open connections.
                 let fd = e.fd();
                 let client_connection = self.connections.get_mut(&fd).unwrap();
+
+                // If we receive a hang up on a connection, we clear the write buffer and set
+                // the connection state to closed to mark it ready for removal from the
+                // connections map, which will gracefully close the socket.
+                // The connection is also marked for removal when encountering `EPOLLERR`,
+                // since this is an "error condition happened on the associated file
+                // descriptor", according to the `epoll_ctl` man page.
+                if e.event_set().contains(epoll::EventSet::ERROR)
+                    || e.event_set().contains(epoll::EventSet::HANG_UP)
+                    || e.event_set().contains(epoll::EventSet::READ_HANG_UP)
+                {
+                    client_connection.clear_write_buffer();
+                    client_connection.state = ClientConnectionState::Closed;
+                    continue;
+                }
+
                 if e.event_set().contains(epoll::EventSet::IN) {
                     // We have bytes to read from this connection.
                     // If our `read` yields `Request` objects, we wrap them with an ID before
@@ -358,7 +379,11 @@ impl HttpServer {
                     // either an error message or an `expect` response, we change its `epoll`
                     // event set to notify us when the stream is ready for writing.
                     if client_connection.state == ClientConnectionState::AwaitingOutgoing {
-                        Self::epoll_mod(&self.epoll, fd, epoll::EventSet::OUT)?;
+                        Self::epoll_mod(
+                            &self.epoll,
+                            fd,
+                            epoll::EventSet::OUT | epoll::EventSet::READ_HANG_UP,
+                        )?;
                     }
                 } else if e.event_set().contains(epoll::EventSet::OUT) {
                     // We have bytes to write on this connection.
@@ -367,7 +392,11 @@ impl HttpServer {
                     // and we don't have any more responses to write, we change the `epoll`
                     // event set to notify us when we have bytes to read from the stream.
                     if client_connection.state == ClientConnectionState::AwaitingIncoming {
-                        Self::epoll_mod(&self.epoll, fd, epoll::EventSet::IN)?;
+                        Self::epoll_mod(
+                            &self.epoll,
+                            fd,
+                            epoll::EventSet::IN | epoll::EventSet::READ_HANG_UP,
+                        )?;
                     }
                 }
             }
@@ -492,7 +521,11 @@ impl HttpServer {
             // `epoll` event set to notify us when the stream is ready for writing.
             if let ClientConnectionState::AwaitingIncoming = client_connection.state {
                 client_connection.state = ClientConnectionState::AwaitingOutgoing;
-                Self::epoll_mod(&self.epoll, response.id as RawFd, epoll::EventSet::OUT)?;
+                Self::epoll_mod(
+                    &self.epoll,
+                    response.id as RawFd,
+                    epoll::EventSet::OUT | epoll::EventSet::READ_HANG_UP,
+                )?;
             }
             client_connection.enqueue_response(response.response)?;
         }
@@ -554,7 +587,10 @@ impl HttpServer {
             .ctl(
                 epoll::ControlOperation::Add,
                 stream_fd,
-                epoll::EpollEvent::new(epoll::EventSet::IN, stream_fd as u64),
+                epoll::EpollEvent::new(
+                    epoll::EventSet::IN | epoll::EventSet::READ_HANG_UP,
+                    stream_fd as u64,
+                ),
             )
             .map_err(ServerError::IOError)
     }
@@ -575,6 +611,7 @@ impl HttpServer {
 mod tests {
     use super::*;
     use std::io::{Read, Write};
+    use std::net::Shutdown;
     use std::os::unix::net::UnixStream;
 
     use crate::common::Body;
@@ -750,7 +787,7 @@ mod tests {
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
-        let mut sockets: Vec<UnixStream> = Vec::with_capacity(11);
+        let mut sockets: Vec<UnixStream> = Vec::with_capacity(MAX_CONNECTIONS + 1);
         for _ in 0..MAX_CONNECTIONS {
             sockets.push(UnixStream::connect(path_to_socket.as_path()).unwrap());
             assert!(server.requests().unwrap().is_empty());
@@ -761,6 +798,38 @@ mod tests {
         let mut buf: [u8; 120] = [0; 120];
         sockets[MAX_CONNECTIONS].read_exact(&mut buf).unwrap();
         assert_eq!(&buf[..], SERVER_FULL_ERROR_MESSAGE);
+        assert_eq!(server.connections.len(), 10);
+        {
+            // Drop this stream.
+            let _refused_stream = sockets.pop().unwrap();
+        }
+        assert_eq!(server.connections.len(), 10);
+
+        // Check that the server detects a connection shutdown.
+        let sock: &UnixStream = sockets.get(0).unwrap();
+        sock.shutdown(Shutdown::Both).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        // Server should drop a closed connection.
+        assert_eq!(server.connections.len(), 9);
+
+        // Close the backing FD of this connection by dropping
+        // it out of scope.
+        {
+            // Enforce the drop call on the stream
+            let _sock = sockets.pop().unwrap();
+        }
+        assert!(server.requests().unwrap().is_empty());
+        // Server should drop a closed connection.
+        assert_eq!(server.connections.len(), 8);
+
+        let sock: &UnixStream = sockets.get(1).unwrap();
+        // Close both the read and write sides of the socket
+        // separately and check that the server detects it.
+        sock.shutdown(Shutdown::Read).unwrap();
+        sock.shutdown(Shutdown::Write).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        // Server should drop a closed connection.
+        assert_eq!(server.connections.len(), 7);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -773,6 +773,14 @@ mod tests {
                               Content-Length: 136\r\n\r\n{ \"error\": \"Invalid header. \
                               Reason: Invalid value. Key:Content-Length; Value: alpha\nAll previous unanswered requests will be dropped.\" }";
         assert_eq!(&buf[..], &error_message[..]);
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: alpha\r\n\
+                         Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -764,14 +764,14 @@ mod tests {
 
         assert!(server.requests().unwrap().is_empty());
         assert!(server.requests().unwrap().is_empty());
-        let mut buf: [u8; 198] = [0; 198];
+        let mut buf: [u8; 255] = [0; 255];
         assert!(socket.read(&mut buf[..]).unwrap() > 0);
         let error_message = b"HTTP/1.1 400 \r\n\
                               Server: Firecracker API\r\n\
                               Connection: keep-alive\r\n\
                               Content-Type: application/json\r\n\
-                              Content-Length: 80\r\n\r\n{ \"error\": \"Invalid header.\n\
-                              All previous unanswered requests will be dropped.\" }";
+                              Content-Length: 136\r\n\r\n{ \"error\": \"Invalid header. \
+                              Reason: Invalid value. Key:Content-Length; Value: alpha\nAll previous unanswered requests will be dropped.\" }";
         assert_eq!(&buf[..], &error_message[..]);
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -397,8 +397,6 @@ impl HttpServer {
     ///
     /// ## Non-blocking server
     /// ```
-    /// extern crate utils;
-    ///
     /// use std::os::unix::io::AsRawFd;
     ///
     /// use micro_http::{HttpServer, Response, StatusCode};

--- a/src/server.rs
+++ b/src/server.rs
@@ -299,10 +299,11 @@ impl HttpServer {
         // current thread until at least one event is received.
         // The received notifications will then populate the `events` array with
         // `event_count` elements, where 1 <= event_count <= MAX_CONNECTIONS.
-        let event_count = self
-            .epoll
-            .wait(MAX_CONNECTIONS, -1, &mut events[..])
-            .map_err(ServerError::IOError)?;
+        let event_count = match self.epoll.wait(MAX_CONNECTIONS, -1, &mut events[..]) {
+            Ok(event_count) => event_count,
+            Err(e) if e.raw_os_error() == Some(libc::EINTR) => 0,
+            Err(e) => return Err(ServerError::IOError(e)),
+        };
         // We use `take()` on the iterator over `events` as, even though only
         // `events_count` events have been inserted into `events`, the size of
         // the array is still `MAX_CONNECTIONS`, so we discard empty elements

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate epoll;
-
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
@@ -17,6 +15,8 @@ use crate::request::Request;
 use crate::response::{Response, StatusCode};
 
 pub use crate::common::ServerError;
+
+use utils::epoll;
 
 static SERVER_FULL_ERROR_MESSAGE: &[u8] = b"HTTP/1.1 503\r\n\
                                             Server: Firecracker API\r\n\
@@ -202,11 +202,11 @@ impl<T: Read + Write> ClientConnection<T> {
 /// requests and sends responses for awaiting requests is `requests`.
 /// It can be called in a loop, which will render the thread that the
 /// server runs on incapable of performing other operations, or it can
-/// be used in another `EPOLL` structure, as it provides its `epoll_fd`,
-/// the file descriptor of the epoll structure used within the server,
-/// and it can be added to another one using the `EPOLLIN` flag. Whenever
-/// there is a notification on that fd, `requests` should be
-/// called once.
+/// be used in another `EPOLL` structure, as it provides its `epoll`,
+/// which is a wrapper over the file descriptor of the epoll structure
+/// used within the server, and it can be added to another one using
+/// the `EPOLLIN` flag. Whenever there is a notification on that fd,
+/// `requests` should be called once.
 ///
 /// # Example
 ///
@@ -241,8 +241,8 @@ impl<T: Read + Write> ClientConnection<T> {
 pub struct HttpServer {
     /// Socket on which we listen for new connections.
     socket: UnixListener,
-    /// File descriptor of the server's epoll structure.
-    epoll_fd: RawFd,
+    /// Server's epoll instance.
+    epoll: epoll::Epoll,
     /// Holds the token-connection pairs of the server.
     /// Each connection has an associated identification token, which is
     /// the file descriptor of the underlying stream.
@@ -260,10 +260,10 @@ impl HttpServer {
     /// Returns an `IOError` when binding or `epoll::create` fails.
     pub fn new<P: AsRef<Path>>(path_to_socket: P) -> Result<Self> {
         let socket = UnixListener::bind(path_to_socket).map_err(ServerError::IOError)?;
-        let epoll_fd = epoll::create(true).map_err(ServerError::IOError)?;
+        let epoll = epoll::Epoll::new().map_err(ServerError::IOError)?;
         Ok(Self {
             socket,
-            epoll_fd,
+            epoll,
             connections: HashMap::new(),
         })
     }
@@ -272,7 +272,7 @@ impl HttpServer {
     pub fn start_server(&mut self) -> Result<()> {
         // Add the socket on which we listen for new connections to the
         // `epoll` structure.
-        Self::epoll_add(self.epoll_fd, self.socket.as_raw_fd())
+        Self::epoll_add(&self.epoll, self.socket.as_raw_fd())
     }
 
     /// This function is responsible for the data exchange with the clients and should
@@ -294,17 +294,15 @@ impl HttpServer {
     /// on a connection on which it is not possible.
     pub fn requests(&mut self) -> Result<Vec<ServerRequest>> {
         let mut parsed_requests: Vec<ServerRequest> = vec![];
-        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); MAX_CONNECTIONS];
-
+        let mut events = vec![epoll::EpollEvent::default(); MAX_CONNECTIONS];
         // This is a wrapper over the syscall `epoll_wait` and it will block the
         // current thread until at least one event is received.
         // The received notifications will then populate the `events` array with
         // `event_count` elements, where 1 <= event_count <= MAX_CONNECTIONS.
-        let event_count = match epoll::wait(self.epoll_fd, -1, &mut events[..]) {
-            Ok(event_count) => event_count,
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => 0,
-            Err(e) => return Err(ServerError::IOError(e)),
-        };
+        let event_count = self
+            .epoll
+            .wait(MAX_CONNECTIONS, -1, &mut events[..])
+            .map_err(ServerError::IOError)?;
         // We use `take()` on the iterator over `events` as, even though only
         // `events_count` events have been inserted into `events`, the size of
         // the array is still `MAX_CONNECTIONS`, so we discard empty elements
@@ -313,7 +311,7 @@ impl HttpServer {
             // Check the file descriptor which produced the notification `e`.
             // It could be that we have a new connection, or one of our open
             // connections is ready to exchange data with a client.
-            if e.data as RawFd == self.socket.as_raw_fd() {
+            if e.fd() == self.socket.as_raw_fd() {
                 // We have received a notification on the listener socket, which
                 // means we have a new connection to accept.
                 match self.handle_new_connection() {
@@ -336,9 +334,9 @@ impl HttpServer {
                 };
             } else {
                 // We have a notification on one of our open connections.
-                let fd = e.data as RawFd;
+                let fd = e.fd();
                 let client_connection = self.connections.get_mut(&fd).unwrap();
-                if e.events & epoll::Events::EPOLLIN.bits() != 0 {
+                if e.event_set().contains(epoll::EventSet::IN) {
                     // We have bytes to read from this connection.
                     // If our `read` yields `Request` objects, we wrap them with an ID before
                     // handing them to the user.
@@ -346,23 +344,23 @@ impl HttpServer {
                         &mut client_connection
                             .read()?
                             .into_iter()
-                            .map(|request| ServerRequest::new(request, fd as u64))
+                            .map(|request| ServerRequest::new(request, e.data()))
                             .collect(),
                     );
                     // If the connection was incoming before we read and we now have to write
                     // either an error message or an `expect` response, we change its `epoll`
                     // event set to notify us when the stream is ready for writing.
                     if client_connection.state == ClientConnectionState::AwaitingOutgoing {
-                        Self::epoll_mod(self.epoll_fd, fd, epoll::Events::EPOLLOUT)?;
+                        Self::epoll_mod(&self.epoll, fd, epoll::EventSet::OUT)?;
                     }
-                } else if e.events & epoll::Events::EPOLLOUT.bits() != 0 {
+                } else if e.event_set().contains(epoll::EventSet::OUT) {
                     // We have bytes to write on this connection.
                     client_connection.write()?;
                     // If the connection was outgoing before we tried to write the responses
                     // and we don't have any more responses to write, we change the `epoll`
                     // event set to notify us when we have bytes to read from the stream.
                     if client_connection.state == ClientConnectionState::AwaitingIncoming {
-                        Self::epoll_mod(self.epoll_fd, fd, epoll::Events::EPOLLIN)?;
+                        Self::epoll_mod(&self.epoll, fd, epoll::EventSet::IN)?;
                     }
                 }
             }
@@ -386,18 +384,21 @@ impl HttpServer {
     /// The file descriptor of the `epoll` structure can enable the server to become
     /// a non-blocking structure in an application.
     ///
-    /// Returns the file descriptor of the server's internal `epoll` structure.
+    /// Returns a reference to the instance of the server's internal `epoll` structure.
     ///
     /// # Example
     ///
     /// ## Non-blocking server
     /// ```
-    /// extern crate epoll;
+    /// extern crate utils;
+    ///
+    /// use std::os::unix::io::AsRawFd;
     ///
     /// use micro_http::{HttpServer, Response, StatusCode};
+    /// use utils::epoll;
     ///
     /// // Create our epoll manager.
-    /// let epoll_fd = epoll::create(true).unwrap();
+    /// let epoll = epoll::Epoll::new().unwrap();
     ///
     /// let path_to_socket = "/tmp/epoll_example.sock";
     /// std::fs::remove_file(path_to_socket).unwrap_or_default();
@@ -407,11 +408,10 @@ impl HttpServer {
     /// server.start_server().unwrap();
     ///
     /// // Add our server to the `epoll` manager.
-    /// epoll::ctl(
-    ///     epoll_fd,
-    ///     epoll::ControlOptions::EPOLL_CTL_ADD,
-    ///     server.epoll_fd(),
-    ///     epoll::Event::new(epoll::Events::EPOLLIN, 1234u64),
+    /// epoll.ctl(
+    ///     epoll::ControlOperation::Add,
+    ///     server.epoll().as_raw_fd(),
+    ///     &epoll::EpollEvent::new(epoll::EventSet::IN, 1234u64),
     /// )
     /// .unwrap();
     ///
@@ -421,9 +421,9 @@ impl HttpServer {
     /// // Control loop of the application.
     /// let mut events = Vec::with_capacity(10);
     /// loop {
-    ///     let num_ev = epoll::wait(epoll_fd, -1, events.as_mut_slice());
+    ///     let num_ev = epoll.wait(10, -1, events.as_mut_slice());
     ///     for event in events {
-    ///         match event.data {
+    ///         match event.data() {
     ///             // The server notification.
     ///             1234 => {
     ///                 let request = server.requests();
@@ -439,8 +439,8 @@ impl HttpServer {
     ///     break;
     /// }
     /// ```
-    pub fn epoll_fd(&self) -> RawFd {
-        self.epoll_fd
+    pub fn epoll(&self) -> &epoll::Epoll {
+        &self.epoll
     }
 
     /// Enqueues the provided responses in the outgoing connection.
@@ -465,7 +465,7 @@ impl HttpServer {
             // `epoll` event set to notify us when the stream is ready for writing.
             if let ClientConnectionState::AwaitingIncoming = client_connection.state {
                 client_connection.state = ClientConnectionState::AwaitingOutgoing;
-                Self::epoll_mod(self.epoll_fd, response.id as RawFd, epoll::Events::EPOLLOUT)?;
+                Self::epoll_mod(&self.epoll, response.id as RawFd, epoll::EventSet::OUT)?;
             }
             client_connection.enqueue_response(response.response);
         }
@@ -496,7 +496,7 @@ impl HttpServer {
             })
             .and_then(|stream| {
                 // Add the stream to the `epoll` structure and listen for bytes to be read.
-                Self::epoll_add(self.epoll_fd, stream.as_raw_fd())?;
+                Self::epoll_add(&self.epoll, stream.as_raw_fd())?;
                 // Then add it to our open connections.
                 self.connections.insert(
                     stream.as_raw_fd(),
@@ -511,29 +511,25 @@ impl HttpServer {
     ///
     /// # Errors
     /// `IOError` is returned when an `EPOLL_CTL_MOD` control operation fails.
-    fn epoll_mod(epoll_fd: RawFd, stream_fd: RawFd, evset: epoll::Events) -> Result<()> {
-        let event = epoll::Event::new(evset, stream_fd as u64);
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_MOD,
-            stream_fd,
-            event,
-        )
-        .map_err(ServerError::IOError)
+    fn epoll_mod(epoll: &epoll::Epoll, stream_fd: RawFd, evset: epoll::EventSet) -> Result<()> {
+        let event = epoll::EpollEvent::new(evset, stream_fd as u64);
+        epoll
+            .ctl(epoll::ControlOperation::Modify, stream_fd, &event)
+            .map_err(ServerError::IOError)
     }
 
     /// Adds a stream to the `epoll` notification structure with the `EPOLLIN` event set.
     ///
     /// # Errors
     /// `IOError` is returned when an `EPOLL_CTL_ADD` control operation fails.
-    fn epoll_add(epoll_fd: RawFd, stream_fd: RawFd) -> Result<()> {
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_ADD,
-            stream_fd,
-            epoll::Event::new(epoll::Events::EPOLLIN, stream_fd as u64),
-        )
-        .map_err(ServerError::IOError)
+    fn epoll_add(epoll: &epoll::Epoll, stream_fd: RawFd) -> Result<()> {
+        epoll
+            .ctl(
+                epoll::ControlOperation::Add,
+                stream_fd,
+                &epoll::EpollEvent::new(epoll::EventSet::IN, stream_fd as u64),
+            )
+            .map_err(ServerError::IOError)
     }
 
     /// Removes a stream to the `epoll` notification structure.
@@ -555,7 +551,7 @@ mod tests {
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
 
-    use crate::common::Body;
+    use common::Body;
 
     #[test]
     fn test_wait_one_connection() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,13 +8,12 @@ use std::os::unix::io::RawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 
-use crate::common::ConnectionError;
 use crate::common::{Body, Version};
+pub use crate::common::{ConnectionError, RequestError, ServerError};
 use crate::connection::HttpConnection;
 use crate::request::Request;
 use crate::response::{Response, StatusCode};
-
-pub use crate::common::ServerError;
+use std::collections::HashMap;
 
 use utils::epoll;
 
@@ -559,7 +558,7 @@ mod tests {
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
 
-    use common::Body;
+    use crate::common::Body;
     use utils::tempfile::TempFile;
 
     fn get_temp_socket_file() -> TempFile {

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,7 +38,7 @@ impl ServerRequest {
     /// Creates a new `ServerRequest` object from an existing `Request`,
     /// adding an identification token.
     pub fn new(request: Request, id: u64) -> Self {
-        ServerRequest { request, id }
+        Self { request, id }
     }
 
     /// Returns a reference to the inner request.
@@ -68,8 +68,8 @@ pub struct ServerResponse {
 }
 
 impl ServerResponse {
-    fn new(response: Response, id: u64) -> ServerResponse {
-        ServerResponse { response, id }
+    fn new(response: Response, id: u64) -> Self {
+        Self { response, id }
     }
 }
 
@@ -97,7 +97,7 @@ struct ClientConnection<T> {
 
 impl<T: Read + Write> ClientConnection<T> {
     fn new(connection: HttpConnection<T>) -> Self {
-        ClientConnection {
+        Self {
             connection,
             state: ClientConnectionState::AwaitingIncoming,
             in_flight_response_count: 0,
@@ -198,13 +198,14 @@ impl<T: Read + Write> ClientConnection<T> {
 /// HTTP Server implementation using Unix Domain Sockets and `EPOLL` to
 /// handle multiple connections on the same thread.
 ///
-/// The function that does the data exchange is `handle_notifications`.
+/// The function that handles incoming connections, parses incoming
+/// requests and sends responses for awaiting requests is `requests`.
 /// It can be called in a loop, which will render the thread that the
 /// server runs on incapable of performing other operations, or it can
 /// be used in another `EPOLL` structure, as it provides its `epoll_fd`,
 /// the file descriptor of the epoll structure used within the server,
 /// and it can be added to another one using the `EPOLLIN` flag. Whenever
-/// there is a notification on that fd, `handle_notifications` should be
+/// there is a notification on that fd, `requests` should be
 /// called once.
 ///
 /// # Example
@@ -260,7 +261,7 @@ impl HttpServer {
     pub fn new<P: AsRef<Path>>(path_to_socket: P) -> Result<Self> {
         let socket = UnixListener::bind(path_to_socket).map_err(ServerError::IOError)?;
         let epoll_fd = epoll::create(true).map_err(ServerError::IOError)?;
-        Ok(HttpServer {
+        Ok(Self {
             socket,
             epoll_fd,
             connections: HashMap::new(),
@@ -474,7 +475,8 @@ impl HttpServer {
     /// Accepts a new incoming connection and adds it to the `epoll` notification structure.
     ///
     /// # Errors
-    /// `IOError` is returned when an `epoll::ctl` operation fails.
+    /// `IOError` is returned when socket or epoll operations fail.
+    /// `ServerFull` is returned if server full capacity has been reached.
     fn handle_new_connection(&mut self) -> Result<()> {
         if self.connections.len() == MAX_CONNECTIONS {
             // If we want a replacement policy for connections
@@ -506,6 +508,9 @@ impl HttpServer {
 
     /// Changes the event type for a connection to either listen for incoming bytes
     /// or for when the stream is ready for writing.
+    ///
+    /// # Errors
+    /// `IOError` is returned when an `EPOLL_CTL_MOD` control operation fails.
     fn epoll_mod(epoll_fd: RawFd, stream_fd: RawFd, evset: epoll::Events) -> Result<()> {
         let event = epoll::Event::new(evset, stream_fd as u64);
         epoll::ctl(
@@ -518,6 +523,9 @@ impl HttpServer {
     }
 
     /// Adds a stream to the `epoll` notification structure with the `EPOLLIN` event set.
+    ///
+    /// # Errors
+    /// `IOError` is returned when an `EPOLL_CTL_ADD` control operation fails.
     fn epoll_add(epoll_fd: RawFd, stream_fd: RawFd) -> Result<()> {
         epoll::ctl(
             epoll_fd,

--- a/src/server.rs
+++ b/src/server.rs
@@ -548,22 +548,27 @@ impl HttpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
 
     use common::Body;
+    use utils::tempfile::TempFile;
+
+    fn get_path_to_socket() -> TempFile {
+        let mut path_to_socket = TempFile::new().unwrap();
+        path_to_socket.remove().unwrap();
+        path_to_socket
+    }
 
     #[test]
     fn test_wait_one_connection() {
-        let path_to_socket = "/tmp/test_socket_http_server1.sock";
-        fs::remove_file(path_to_socket).unwrap_or_default();
+        let path_to_socket = get_path_to_socket();
 
-        let mut server = HttpServer::new(path_to_socket.to_string()).unwrap();
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
         // Test one incoming connection.
-        let mut socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
         assert!(server.requests().unwrap().is_empty());
 
         socket
@@ -589,19 +594,17 @@ mod tests {
 
         let mut buf: [u8; 1024] = [0; 1024];
         assert!(socket.read(&mut buf[..]).unwrap() > 0);
-        fs::remove_file(path_to_socket).unwrap();
     }
 
     #[test]
     fn test_wait_concurrent_connections() {
-        let path_to_socket = "/tmp/test_socket_http_server2.sock";
-        fs::remove_file(path_to_socket).unwrap_or_default();
+        let path_to_socket = get_path_to_socket();
 
-        let mut server = HttpServer::new(path_to_socket.to_string()).unwrap();
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
         // Test two concurrent connections.
-        let mut first_socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut first_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
         assert!(server.requests().unwrap().is_empty());
 
         first_socket
@@ -611,7 +614,7 @@ mod tests {
                                Content-Type: application/json\r\n\r\nwhatever body",
             )
             .unwrap();
-        let mut second_socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut second_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
 
         let mut req_vec = server.requests().unwrap();
         let server_request = req_vec.remove(0);
@@ -663,19 +666,17 @@ mod tests {
         assert!(second_socket.read(&mut buf[..]).unwrap() > 0);
         second_socket.shutdown(std::net::Shutdown::Both).unwrap();
         assert!(server.requests().unwrap().is_empty());
-        fs::remove_file(path_to_socket).unwrap();
     }
 
     #[test]
     fn test_wait_expect_connection() {
-        let path_to_socket = "/tmp/test_socket_http_server3.sock";
-        fs::remove_file(path_to_socket).unwrap_or_default();
+        let path_to_socket = get_path_to_socket();
 
-        let mut server = HttpServer::new(path_to_socket.to_string()).unwrap();
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
         // Test one incoming connection with `Expect: 100-continue`.
-        let mut socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
         assert!(server.requests().unwrap().is_empty());
 
         socket
@@ -714,42 +715,37 @@ mod tests {
 
         let mut buf: [u8; 1024] = [0; 1024];
         assert!(socket.read(&mut buf[..]).unwrap() > 0);
-        fs::remove_file(path_to_socket).unwrap();
     }
 
     #[test]
     fn test_wait_many_connections() {
-        let path_to_socket = "/tmp/test_socket_http_server4.sock";
-        fs::remove_file(path_to_socket).unwrap_or_default();
+        let path_to_socket = get_path_to_socket();
 
-        let mut server = HttpServer::new(path_to_socket.to_string()).unwrap();
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
         let mut sockets: Vec<UnixStream> = Vec::with_capacity(11);
         for _ in 0..MAX_CONNECTIONS {
-            sockets.push(UnixStream::connect(path_to_socket).unwrap());
+            sockets.push(UnixStream::connect(path_to_socket.as_path()).unwrap());
             assert!(server.requests().unwrap().is_empty());
         }
 
-        sockets.push(UnixStream::connect(path_to_socket).unwrap());
+        sockets.push(UnixStream::connect(path_to_socket.as_path()).unwrap());
         assert!(server.requests().unwrap().is_empty());
         let mut buf: [u8; 120] = [0; 120];
         sockets[MAX_CONNECTIONS].read_exact(&mut buf).unwrap();
         assert_eq!(&buf[..], SERVER_FULL_ERROR_MESSAGE);
-
-        fs::remove_file(path_to_socket).unwrap();
     }
 
     #[test]
     fn test_wait_parse_error() {
-        let path_to_socket = "/tmp/test_socket_http_server5.sock";
-        fs::remove_file(path_to_socket).unwrap_or_default();
+        let path_to_socket = get_path_to_socket();
 
-        let mut server = HttpServer::new(path_to_socket.to_string()).unwrap();
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
         // Test one incoming connection.
-        let mut socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
         socket.set_nonblocking(true).unwrap();
         assert!(server.requests().unwrap().is_empty());
 
@@ -772,22 +768,19 @@ mod tests {
                               Content-Length: 80\r\n\r\n{ \"error\": \"Invalid header.\n\
                               All previous unanswered requests will be dropped.\" }";
         assert_eq!(&buf[..], &error_message[..]);
-
-        fs::remove_file(path_to_socket).unwrap();
     }
 
     #[test]
     fn test_wait_in_flight_responses() {
-        let path_to_socket = "/tmp/test_socket_http_server6.sock";
-        fs::remove_file(path_to_socket).unwrap_or_default();
+        let path_to_socket = get_path_to_socket();
 
-        let mut server = HttpServer::new(path_to_socket.to_string()).unwrap();
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
 
         // Test a connection dropped and then a new one appearing
         // before the user had a chance to send the response to the
         // first one.
-        let mut first_socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut first_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
         assert!(server.requests().unwrap().is_empty());
 
         first_socket
@@ -803,7 +796,7 @@ mod tests {
 
         first_socket.shutdown(std::net::Shutdown::Both).unwrap();
         assert!(server.requests().unwrap().is_empty());
-        let mut second_socket = UnixStream::connect(path_to_socket).unwrap();
+        let mut second_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
         second_socket.set_nonblocking(true).unwrap();
         assert!(server.requests().unwrap().is_empty());
 
@@ -855,6 +848,5 @@ mod tests {
         assert!(second_socket.read(&mut buf[..]).unwrap() > 0);
         second_socket.shutdown(std::net::Shutdown::Both).unwrap();
         assert!(server.requests().is_ok());
-        fs::remove_file(path_to_socket).unwrap();
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -419,7 +419,7 @@ impl HttpServer {
     /// epoll.ctl(
     ///     epoll::ControlOperation::Add,
     ///     server.epoll().as_raw_fd(),
-    ///     &epoll::EpollEvent::new(epoll::EventSet::IN, 1234u64),
+    ///     epoll::EpollEvent::new(epoll::EventSet::IN, 1234u64),
     /// )
     /// .unwrap();
     ///
@@ -523,7 +523,7 @@ impl HttpServer {
     fn epoll_mod(epoll: &epoll::Epoll, stream_fd: RawFd, evset: epoll::EventSet) -> Result<()> {
         let event = epoll::EpollEvent::new(evset, stream_fd as u64);
         epoll
-            .ctl(epoll::ControlOperation::Modify, stream_fd, &event)
+            .ctl(epoll::ControlOperation::Modify, stream_fd, event)
             .map_err(ServerError::IOError)
     }
 
@@ -536,7 +536,7 @@ impl HttpServer {
             .ctl(
                 epoll::ControlOperation::Add,
                 stream_fd,
-                &epoll::EpollEvent::new(epoll::EventSet::IN, stream_fd as u64),
+                epoll::EpollEvent::new(epoll::EventSet::IN, stream_fd as u64),
             )
             .map_err(ServerError::IOError)
     }

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::Ipv4Addr;
+
+/// Keeps the MMDS configuration.
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MmdsConfig {
+    /// MMDS IPv4 configured address.
+    ipv4_address: Option<Ipv4Addr>,
+}
+
+impl MmdsConfig {
+    /// Returns the MMDS IPv4 address if one was configured.
+    /// Otherwise returns None.
+    pub fn ipv4_addr(&self) -> Option<Ipv4Addr> {
+        self.ipv4_address
+    }
+}

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{export::Formatter, Deserialize};
+use std::fmt::{Display, Result};
 use std::net::Ipv4Addr;
 
 /// Keeps the MMDS configuration.


### PR DESCRIPTION
## Reason for This PR

This repo is forked and based on upstream repo [firecracker/micro-http](https://github.com/firecracker-microvm/micro-http).
The upstream has been improved and fixed by a couple of patches. They are also needed by this repo.

For instance, put request's body will be dropped by micro http server when using http client hyper.

## Description of Changes

Just a Synchronization from upstream.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
